### PR TITLE
 Fixed cleanMapAtSave usage, dynamic broadcast for next save

### DIFF
--- a/data/creaturescripts/creaturescripts.xml
+++ b/data/creaturescripts/creaturescripts.xml
@@ -5,16 +5,16 @@
 	<event type="healthchange" name="HealGaz" script="gaz'haragoth heal.lua"/>	
 
 	<!-- Events -->
-    	<event type="preparedeath" name="BFPrepareDeath" script="battlefield.lua" />
-		<event type="healthchange" name="BFHealthChange" script="battlefield.lua" />
-		<event type="manachange" name="BFManaChange" script="battlefield.lua" />
-		<event type="logout" name="BFLogout" script="battlefield.lua" />
-		<event type="preparedeath" name="CTFDeath" script="ctf.lua" />
-		<event type="healthchange" name="CTFHealthChange" script="ctf.lua" />
-		<event type="logout" name="CityWarLogout" script="citywar.lua" />
-    	<event type="preparedeath" name="CityWarDeath" script="citywar.lua" />
-    	<event type="textedit" name="CityWarInvite" script="citywar.lua" />
-    	<event type="preparedeath" name="ZumbiDeath" script="ZE_creaturescript.lua"/> 
+    	<event type="preparedeath" name="BFPrepareDeath" script="events/battlefield.lua" />
+		<event type="healthchange" name="BFHealthChange" script="events/battlefield.lua" />
+		<event type="manachange" name="BFManaChange" script="events/battlefield.lua" />
+		<event type="logout" name="BFLogout" script="events/battlefield.lua" />
+		<event type="preparedeath" name="CTFDeath" script="events/ctf.lua" />
+		<event type="healthchange" name="CTFHealthChange" script="events/ctf.lua" />
+		<event type="logout" name="CityWarLogout" script="events/citywar.lua" />
+    	<event type="preparedeath" name="CityWarDeath" script="events/citywar.lua" />
+    	<event type="textedit" name="CityWarInvite" script="events/citywar.lua" />
+    	<event type="preparedeath" name="ZumbiDeath" script="events/ZE_creaturescript.lua"/> 
     <!-- END Events -->
 
  	<event type="death" name="DeathCounter" script="kdcounter.lua" />

--- a/data/globalevents/scripts/autosave.lua
+++ b/data/globalevents/scripts/autosave.lua
@@ -1,16 +1,16 @@
-local cleanMapAtSave = true
+local cleanMapAtSave = false
 
-local function serverSave()
+local function serverSave(interval)
 	if cleanMapAtSave then
-		--cleanMap()
-	Game.broadcastMessage('Server Saved, next save in 1 hour.', MESSAGE_STATUS_WARNING)
+		cleanMap()
 	end
 
 	saveServer()
+	Game.broadcastMessage('Server save complete. Next save in ' .. math.floor(interval / 60000) .. ' minutes!', MESSAGE_STATUS_WARNING)
 end
 
 function onThink(interval)
-	Game.broadcastMessage('The server will save all accounts within 60 seconds, possibly will have lag for 5 seconds, find a safe place.', MESSAGE_STATUS_WARNING)
-	addEvent(serverSave, 60000)
+	Game.broadcastMessage('The server will save all accounts within 60 seconds. You might lag or freeze for 5 seconds, please find a safe place.', MESSAGE_STATUS_WARNING)
+	addEvent(serverSave, 60000, interval)
 	return true
 end


### PR DESCRIPTION
cleanMap was commented out. Removed the comment, and defaulted the clean
to false. User can toggle to true if they want the map to clean. Also
adjusted the broadcast to tell when the next save is based on the
interval of the global event instead of a static number, incase someone
wants to make it faster, they dont have to edit the script too.