### PR TITLE
Fixes to tibiaCoins, also fixes from TFS

### DIFF
--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -220,9 +220,10 @@ bool IOLoginData::preloadPlayer(Player* player, const std::string& name)
 
 bool IOLoginData::loadPlayerById(Player* player, uint32_t id)
 {
+	Database& db = Database::getInstance();
 	std::ostringstream query;
 	query << "SELECT `id`, `name`, `account_id`, `group_id`, `sex`, `vocation`, `experience`, `level`, `maglevel`, `health`, `healthmax`, `blessings`, `mana`, `manamax`, `manaspent`, `soul`, `lookbody`, `lookfeet`, `lookhead`, `looklegs`, `looktype`, `lookaddons`, `posx`, `posy`, `posz`, `cap`, `prey_stamina_1`, `prey_stamina_2`, `prey_stamina_3`, `lastlogin`, `lastlogout`, `lastip`, `conditions`, `skulltime`, `skull`, `town_id`, `balance`, `offlinetraining_time`, `offlinetraining_skill`, `stamina`, `skill_fist`, `skill_fist_tries`, `skill_club`, `skill_club_tries`, `skill_sword`, `skill_sword_tries`, `skill_axe`, `skill_axe_tries`, `skill_dist`, `skill_dist_tries`, `skill_shielding`, `skill_shielding_tries`, `skill_fishing`, `skill_fishing_tries`, `skill_critical_hit_chance`, `skill_critical_hit_chance_tries`, `skill_critical_hit_damage`, `skill_critical_hit_damage_tries`, `skill_life_leech_chance`, `skill_life_leech_chance_tries`, `skill_life_leech_amount`, `skill_life_leech_amount_tries`, `skill_mana_leech_chance`, `skill_mana_leech_chance_tries`, `skill_mana_leech_amount`,  `skill_mana_leech_amount_tries` FROM `players` WHERE `id` = " << id;
-	return loadPlayer(player, Database::getInstance().storeQuery(query.str()));
+	return loadPlayer(player, db.storeQuery(query.str()));
 }
 
 bool IOLoginData::loadPlayerPreyById(Player* player, uint32_t id)

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -6563,9 +6563,13 @@ int LuaScriptInterface::luaContainerAddItem(lua_State* L)
 		}
 	}
 
-	uint32_t subType = getNumber<uint32_t>(L, 3, 1);
-
-	Item* item = Item::CreateItem(itemId, std::min<uint32_t>(subType, 100));
+	uint32_t count = getNumber<uint32_t>(L, 3, 1);
+	const ItemType& it = Item::items[itemId];
+	if (it.stackable) {
+		count = std::min<uint16_t>(count, 100);
+	}
+	
+	Item* item = Item::CreateItem(itemId, count);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -9437,9 +9441,9 @@ int LuaScriptInterface::luaPlayerAddTibiaCoins(lua_State* L)
 		return 1;
 	}
 
-	if (player->tibiaCoins != std::numeric_limits<uint64_t>::max()) {
-		uint64_t coins = getNumber<uint64_t>(L, 2);
-		uint64_t addCoins = std::min<uint64_t>(0xFFFFFFFFFFFFFFFE - player->tibiaCoins, coins);
+	if (player->tibiaCoins != std::numeric_limits<int32_t>::max()) {
+		int32_t coins = getNumber<int32_t>(L, 2);
+		int32_t addCoins = std::min<int32_t>(std::numeric_limits<int32_t>::max() - player->tibiaCoins, coins);
 		if (addCoins > 0) {
 			player->setTibiaCoins(player->tibiaCoins + addCoins);
 			IOAccount::addCoins(player->getAccount(), addCoins);
@@ -9458,9 +9462,9 @@ int LuaScriptInterface::luaPlayerRemoveTibiaCoins(lua_State* L)
 		return 1;
 	}
 
-	if (player->tibiaCoins != std::numeric_limits<uint64_t>::max()) {
-		uint64_t coins = getNumber<uint64_t>(L, 2);
-		uint64_t removeCoins = std::min<uint64_t>(player->tibiaCoins, coins);
+	if (player->tibiaCoins != std::numeric_limits<int32_t>::max()) {
+		int32_t coins = getNumber<int32_t>(L, 2);
+		int32_t removeCoins = std::min<int32_t>(player->tibiaCoins, coins);
 		if (removeCoins > 0) {
 			player->setTibiaCoins(player->tibiaCoins - removeCoins);
 			IOAccount::removeCoins(player->getAccount(), removeCoins);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4118,7 +4118,7 @@ void Player::setPremiumDays(int32_t v)
 	sendBasicData();
 }
 
-void Player::setTibiaCoins(uint64_t v)
+void Player::setTibiaCoins(int32_t v)
 {
 	tibiaCoins = v;
 }

--- a/src/player.h
+++ b/src/player.h
@@ -435,7 +435,7 @@ class Player final : public Creature, public Cylinder
 		bool isPremium() const;
 		void setPremiumDays(int32_t v);
 
-		void setTibiaCoins(uint64_t v);
+		void setTibiaCoins(int32_t v);
 
 		uint16_t getHelpers() const;
 
@@ -1432,7 +1432,7 @@ class Player final : public Creature, public Cylinder
 		int32_t saleCallback = -1;
 		int32_t MessageBufferCount = 0;
 		int32_t premiumDays = 0;
-		uint64_t tibiaCoins = 0;
+		int32_t tibiaCoins = 0;
 		int32_t bloodHitCount = 0;
 		int32_t shieldBlockCount = 0;
 		int32_t offlineTrainingSkill = -1;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -133,7 +133,7 @@ void ProtocolGame::login(const std::string& name, uint32_t accountId, OperatingS
 			return;
 		}
 
-		if (!IOLoginData::loadPlayerByName(player, name)) {
+		if (!IOLoginData::loadPlayerById(player, player->getGUID())) {
 			disconnectClient("Your character could not be loaded.");
 			return;
 		}


### PR DESCRIPTION
Fixed tibiaCoins to use int32_t to match the previously existing IOAccount functions to prevent mismatch later (not that anyone should ever achieve this number of coins, but just incase). Also added 2 fixes from TFS to imrpove performance/reliability and standardize db queries for player loading.