### PR TITLE
now it don't drop all items for all killers

### DIFF
--- a/data/creaturescripts/scripts/rewardChest/boss.lua
+++ b/data/creaturescripts/scripts/rewardChest/boss.lua
@@ -145,7 +145,7 @@ function onDeath(creature, corpse, killer, mostDamageKiller, lastHitUnjustified,
 
 			local playerLoot
 			if --[[stamina > 840 and]] con.score ~= 0 then
-				local lootFactor = 1
+				local lootFactor = 0.007
 				lootFactor = lootFactor / participants ^ (1 / 3) -- tone down the loot a notch if there are many participants
 				lootFactor = lootFactor * (1 + lootFactor) ^ (con.score / expectedScore) -- increase the loot multiplicatively by how many times the player surpassed the expected score
 				playerLoot = monsterType:getBossReward(lootFactor, _ == 1)


### PR DESCRIPTION
decreasing the lootFactor should fix the issue that give all items to all players, now is possible work with lower chances, exemple:
<item id="25414" chance="500" unique="1"/><!-- death gaze -->
chance 500 is something like rare, you need kill 10~20 monsters to drop it, ofc you will need be the most pointed player in the battle..
chance 100 is very rare ... etc etc