### PR TITLE
Updating useStaminaXp

### DIFF
--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -528,7 +528,7 @@ local function useStamina(player)
 end
 
 local function useStaminaXp(player)
-	local staminaMinutes = player:getExpBoostStamina()
+	local staminaMinutes = player:getExpBoostStamina() / 60
 	if staminaMinutes == 0 then
 		return
 	end
@@ -551,7 +551,7 @@ local function useStaminaXp(player)
 		staminaMinutes = staminaMinutes - 1
 		nextUseXpStamina[playerId] = currentTime + 60
 	end
-	player:setExpBoostStamina(staminaMinutes)
+	player:setExpBoostStamina(staminaMinutes * 60)
 end
 
 

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -420,7 +420,7 @@ function parseBuyStoreOffer(playerId, msg)
 			local currentExpBoostTime = player:getExpBoostStamina()
 
 			player:setStoreXpBoost(50)
-			player:setStaminaXpBoost(currentExpBoostTime + 60)
+			player:setStaminaXpBoost(currentExpBoostTime + 3600)
 		elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_PREYSLOT then
 			local unlockedColumns = player:getPreySlots()
 			if (unlockedColumns == 2) then


### PR DESCRIPTION
getExpBoostStamina returns stamina in seconds based on this comment from protocolbasegame.cpp on line 239:
msg.add<uint16_t>(player->getExpBoostStamina()); // xp boost time (seconds)
Tibia client is displaying ExpBoostStamina in seconds too.
And addressing this change in gamestore.