### PR TITLE
Fix Loss Bless for pvp and monsters

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2075,11 +2075,11 @@ void Player::death(Creature* lastHitCreature)
 			}
 		}
 
-		if (hasBlessing(6)) {
-			if (lastHitPlayer) {
-				removeBlessing(6, 1);
+		if (hasBlessing(8)) {
+			if (lastHitPlayer && hasBlessing(1)) {
+				removeBlessing(1, 1);
 			} else {
-				for (int i = 1; i <= 5; i++) {
+				for (int i = 1; i <= 8; i++) {
 					removeBlessing(i, 1);
 				}
 			}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2079,7 +2079,7 @@ void Player::death(Creature* lastHitCreature)
 			if (lastHitPlayer && hasBlessing(1)) {
 				removeBlessing(1, 1);
 			} else {
-				for (int i = 1; i <= 8; i++) {
+				for (int i = 2; i <= 8; i++) {
 					removeBlessing(i, 1);
 				}
 			}


### PR DESCRIPTION
Player dead for player, loss bless twisft fate.
Player dead for player and not have twist of fate, loss all bless
Player dead for monster, loss all bless.