### PR TITLE
Fixed ice delivery

### DIFF
--- a/data/actions/scripts/quests/explorer society/icicle.lua
+++ b/data/actions/scripts/quests/explorer society/icicle.lua
@@ -1,5 +1,5 @@
 function onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if target.itemid == 4995 and target.uid == 3000 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 5 then
+	if target.itemid == 4995 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 5 then
 		player:setStorageValue(Storage.ExplorerSociety.QuestLine, 6)
 		player:addItem(4848, 1)
 		toPosition:sendMagicEffect(CONST_ME_MAGIC_BLUE)


### PR DESCRIPTION
The mission ice delivery on the explorer society quest was bugged. When using the ice pick on the ice it wouldn't do anything. Please let me know if this fix is acceptable and won't break anything else