### PR TITLE
Fixed blessing errors on console

### DIFF
--- a/data/npc/lib/npcsystem/modules.lua
+++ b/data/npc/lib/npcsystem/modules.lua
@@ -161,15 +161,15 @@ if Modules == nil then
 		local parseInfo = {[TAG_BLESSCOST] = getBlessingsCost(player:getLevel()), [TAG_PVPBLESSCOST] = getPvpBlessingCost(player:getLevel())}
 		if player:hasBlessing(parameters.bless) then
 			npcHandler:say("You already possess this blessing.", cid)
-		elseif parameters.bless == 7 and player:getStorageValue(Storage.KawillBlessing) ~= 1 then
+		elseif parameters.bless == 3 and player:getStorageValue(Storage.KawillBlessing) ~= 1 then
 			npcHandler:say("You need the blessing of the great geomancer first.", cid)
 		elseif parameters.bless == 1 and player:getBlessings() == 0 and not player:getItemById(2173, true) then
 			npcHandler:say("You don't have any of the other blessings nor an amulet of loss, so it wouldn't make sense to bestow this protection on you now. Remember that it can only protect you from the loss of those!", cid)
-		elseif not player:removeMoneyNpc(type(parameters.cost) == "string" and npcHandler:parseMessage(parameters.cost, parseInfo) or parameters.cost) then
+		elseif not player:removeMoneyNpc(type(parameters.cost) == "string" and tonumber(npcHandler:parseMessage(parameters.cost, parseInfo)) or parameters.cost) then
 			npcHandler:say("Oh. You do not have enough money.", cid)
 		else
 			npcHandler:say(parameters.text or "You have been blessed by one of the seven gods!", cid)
-			if parameters.bless == 7 then
+			if parameters.bless == 3 then
 				player:setStorageValue(Storage.KawillBlessing, 0)
 			end
 			player:addBlessing(parameters.bless, 1)

--- a/data/npc/scripts/Humphrey.lua
+++ b/data/npc/scripts/Humphrey.lua
@@ -9,7 +9,7 @@ function onThink()				npcHandler:onThink()					end
 
 -- Embrace of Tibia
 local blessKeyword = keywordHandler:addKeyword({'embrace'}, StdModule.say, {npcHandler = npcHandler, text = 'Would you like to receive that protection for a sacrifice of |BLESSCOST| gold, child?'})
-	blessKeyword:addChildKeyword({'yes'}, StdModule.bless, {npcHandler = npcHandler, text = 'So receive the embrace of Tibia, pilgrim.', cost = '|BLESSCOST|', bless = 5})
+	blessKeyword:addChildKeyword({'yes'}, StdModule.bless, {npcHandler = npcHandler, text = 'So receive the embrace of Tibia, pilgrim.', cost = '|BLESSCOST|', bless = 6})
 	blessKeyword:addChildKeyword({''}, StdModule.say, {npcHandler = npcHandler, text = 'Fine. You are free to decline my offer.', reset = true})
 
 -- Healing

--- a/data/npc/scripts/Nomad.lua
+++ b/data/npc/scripts/Nomad.lua
@@ -9,7 +9,7 @@ function onThink()				npcHandler:onThink()					end
 
 -- Heart of the Mountain
 local blessKeyword = keywordHandler:addKeyword({'heart'}, StdModule.say, {npcHandler = npcHandler, text = 'Would you like to receive that protection for a sacrifice of |BLESSCOST| gold, child?'})
-	blessKeyword:addChildKeyword({'yes'}, StdModule.bless, {npcHandler = npcHandler, text = 'So receive the Heart of the Mountain, pilgrim.', cost = '|BLESSCOST|', bless = 7})
+	blessKeyword:addChildKeyword({'yes'}, StdModule.bless, {npcHandler = npcHandler, text = 'So receive the Heart of the Mountain, pilgrim.', cost = '|BLESSCOST|', bless = 8})
 	blessKeyword:addChildKeyword({''}, StdModule.say, {npcHandler = npcHandler, text = 'Fine. You are free to decline my offer.', reset = true})
 
 -- Healing


### PR DESCRIPTION
When trying to buy bless the console displays the error: data/npc/lib/npcsystem/customModules.lua:223: attempt to compare number with string.