### PR TITLE
Fixed buying keg in inGameStore (not enough cap)

### DIFF
--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -310,7 +310,7 @@ function parseBuyStoreOffer(playerId, msg)
 			end
 			if(isKegItem(offer.thingId)) and player:getFreeCapacity() < ItemType(offer.thingId):getWeight(1) then
 				return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "Please make sure you have free capacity to hold this item.")
-			elseif player:getFreeCapacity() < ItemType(offer.thingId):getWeight(offer.count) then
+			elseif not isKegItem(offer.thingId) and player:getFreeCapacity() < ItemType(offer.thingId):getWeight(offer.count) then
 				return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "Please make sure you have free capacity to hold this item.")
 			end
 			local inbox = player:getSlotItem(CONST_SLOT_STORE_INBOX)

--- a/data/spells/spells.xml
+++ b/data/spells/spells.xml
@@ -21,11 +21,11 @@
 		<vocation name="Elder Druid"/>
 	</instant>
 	<!-- under construction -->
-	<conjure group="support" spellid="176" name="Conjure Diamond Arrow" words="exevo gran con hur" lvl="150" mana="1000" soul="0" prem="1" conjureId="29056" conjureCount="100" exhaustion="600000" groupcooldown="2000" needlearn="0" function="conjureItem">
+	<conjure group="support" spellid="176" name="Conjure Diamond Arrow" words="exevo gran con hur" lvl="150" mana="1000" soul="0" prem="1" conjureId="29057" conjureCount="100" exhaustion="600000" groupcooldown="2000" needlearn="0" function="conjureItem">
 		<vocation name="Paladin" />
 		<vocation name="Royal Paladin" />
 	</conjure>
-	<conjure group="support" spellid="192" name="Conjure Spectral Bolt" words="exevo gran con vis" lvl="150" mana="1000" soul="0" prem="1" conjureId="29057" conjureCount="100" exhaustion="600000" groupcooldown="2000" needlearn="0" function="conjureItem">
+	<conjure group="support" spellid="192" name="Conjure Spectral Bolt" words="exevo gran con vis" lvl="150" mana="1000" soul="0" prem="1" conjureId="29058" conjureCount="100" exhaustion="600000" groupcooldown="2000" needlearn="0" function="conjureItem">
 		<vocation name="Paladin" />
 		<vocation name="Royal Paladin" />
 	</conjure>


### PR DESCRIPTION
Fixed Conjure Diamond Arrow and Conjure Spectral Bolt, wrong ids of items

### Checklist for this pull request
🚨 Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository. 🚨

- [ ] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [ ] Check the all commits' message styles matches our requested structure.
- [ ] Check your code follow the same styles as the repo.

### Description
Fixed logic in inGameStore, because buying keg's were bugged
Changed Conjure spells items id, because it was wrong
