### PR TITLE
Gamestore update and bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 /build
 /.vscode
+#clion ide files
+.idea/
+#clion build files
+/cmake-build-debug
+#map
+/data/world/realmap.otbm
+#binary
+tfs

--- a/data/actions/actions.xml
+++ b/data/actions/actions.xml
@@ -967,6 +967,7 @@
 	<action itemid="20254" script="other/constructionkits.lua" />
 	<action itemid="20255" script="other/constructionkits.lua" />
 	<action itemid="20257" script="other/constructionkits.lua" />
+	<action itemid="26054" script="other/store_constructionkits.lua" />
 
 	
 	<action fromid="7904" toid="7907" script="other/bed_modification_kits.lua" />

--- a/data/actions/scripts/other/store_constructionkits.lua
+++ b/data/actions/scripts/other/store_constructionkits.lua
@@ -1,0 +1,19 @@
+function onUse(player, item, fromPosition, target, toPosition, isHotkey)
+  local kit = item.actionid
+  print(item.actionid)
+  if not kit then
+    return false
+  end
+
+  if fromPosition.x == CONTAINER_POSITION then
+    player:sendTextMessage(MESSAGE_STATUS_SMALL, "Put the construction kit on the floor first.")
+  elseif not fromPosition:getTile():getHouse() then
+    player:sendTextMessage(MESSAGE_STATUS_SMALL, "You may construct this only inside a house.")
+  else
+    item:transform(kit)
+    fromPosition:sendMagicEffect(CONST_ME_POFF)
+    player:addAchievementProgress('Interior Decorator', 1000)
+  end
+
+  return true
+end

--- a/data/creaturescripts/scripts/others/login.lua
+++ b/data/creaturescripts/scripts/others/login.lua
@@ -61,7 +61,7 @@ local events = {
 	'petthink',
 	'UpperSpikeKill',
 	'MiddleSpikeKill',
-	'LowerSpikeKill'
+	'LowerSpikeKill',
   'LadyTenebrisKilled',
   'LloydKilled',
   'ThornKnightKilled',

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -185,6 +185,7 @@ function Player:onLook(thing, position, distance)
 		if thing:isCreature() then
 			if thing:isPlayer() then
 				description = string.format("%s\nIP: %s.", description, Game.convertIpToString(thing:getIp()))
+				description = string.format("%s\nLooktype: %s.", description,  thing:getOutfit().lookType)
 			end
 		end
 	end
@@ -413,7 +414,7 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 
 	-- No move parcel very heavy
 	if item:getWeight() > 90000 and item:getId() == ITEM_PARCEL then
-		self:sendCancelMessage('YOU CANNOT MOVE PARCELS TOO HEAVY.')
+		self:sendCancelMessage("You can't move this parcel. It's too heavy.")
 		return false
 	end
 

--- a/data/lib/miscellaneous/051-storages.lua
+++ b/data/lib/miscellaneous/051-storages.lua
@@ -3,77 +3,182 @@
 -- Sort it in Values -
 
 Storage = {
-	SweetyCyclops = {
-		AmuletTimer = 48,
-		AmuletStatus = 49
-	},
-	ExplorerSociety = {
-		QuestLine = 90,
-		bansheeDoor = 91,
-		bonelordsDoor = 92,
-		CalassaQuest = 93,
-		edronDoor = 94,
-		elvenDoor = 95,
-		orcDoor = 96,
-		urnDoor = 97,
-		SpectralStone = 98,		-- = 1 - mission taken from Angus, = 2 - mission taken from Mortimer
-		skullofratha = 99,
-		giantsmithhammer = 100
-	},
-	TravellingTrader = {
-		Mission01 = 101,
-		Mission02 = 102,
-		Mission03 = 103,
-		Mission04 = 104,
-		Mission05 = 105,
-		Mission06 = 106,
-		Mission07 = 107,
-		packageDoor = 108
-	},
-	DjinnWar = {
-		Faction = {
-			Greeting = 50717,
-			Marid = 50718,
-			Efreet = 50719
-		},
+  TheFirstDragon = {
+    Timer = 34020,
+    SomewhatCounter = 34021,
+    SomewhatStatus = 34022,
+
+    -- Task Tazhadur
+    Tazhadur = 34000,
+    DragonCount = 34001,	-- Conta os dragões para liberar o boss
+
+    -- Task Kalyassa
+    Kalyassa = 34002,
+    Treasure = 34003,
+
+    -- Task Zorvorax
+    Oasis = 34004,
+    Stone = 34005,
+    Suntower = 34006,
+    Zorvorax = 34007,
+    Steps = 34015,
+
+    -- Task Gelidrazah
+    Gelidrazah = 34008,
+    Npc = 34009,
+
+    -- First Dragon
+    FirstDragon = 34010,
+
+    -- Rewards
+    Reward1 = 34011,
+    Reward2 = 34012,
+    Reward3 = 34013,
+
+    -- Start
+    Progresso = 34014
+  },
+  DeeplingBosses = {
+    Jaul = 35600,
+    Tanjis = 35601,
+    Obujos = 35602,
+    DeeplingStatus = 35603
+  },
+  Grimvale = {
+    SilverVein = 10094
+  },
+  RathletonQuest = {
+    QuestLine = 10068,
+    VotesCasted = 10069,
+    Rank = 10070
+  },
+  ForgottenKnowledge = {
+    AccessDeath = 10132,
+    AccessViolet = 10133,
+    AccessEarth = 10134,
+    AccessFire = 10135,
+    AccessIce = 10136,
+    AccessGolden = 10137,
+    AccessLast = 10138,
+    OldDesk = 10139,
+    GirlPicture = 10140,
+    SilverKey = 10141,
+    Phial = 10142,
+    BirdCounter = 10143,
+    PlantCounter = 10144,
+    GoldenServantCounter = 10145,
+    DiamondServantCounter = 10146,
+    AccessPortals = 10147,
+    AccessMachine = 10148,
+    LadyTenebrisTimer = 10149,
+    LadyTenebrisKilled = 10150,
+    LloydTimer = 10151,
+    LloydKilled = 10152,
+    ThornKnightTimer = 10153,
+    ThornKnightKilled = 10154,
+    DragonkingTimer = 10155,
+    DragonkingKilled = 10156,
+    HorrorTimer = 10157,
+    HorrorKilled = 10158,
+    TimeGuardianTimer = 10159,
+    TimeGuardianKilled = 10160,
+    LastLoreTimer = 10161,
+    LastLoreKilled = 10162,
+    BirdCage = 10163,
+    AccessLavaTeleport = 10164,
+    Ivalisse = 10165,
+    Chalice = 10166,
+    Tomes = 10167,
+    BabyDragon = 10168,
+    SpiderWeb = 10169
+  },
+  SweetyCyclops = {
+    AmuletTimer = 48,
+    AmuletStatus = 49
+  },
+  ExplorerSociety = {
+    QuestLine = 90,
+    bansheeDoor = 91,
+    bonelordsDoor = 92,
+    CalassaQuest = 93,
+    edronDoor = 94,
+    elvenDoor = 95,
+    orcDoor = 96,
+    urnDoor = 97,
+    SpectralStone = 98,		-- = 1 - mission taken from Angus, = 2 - mission taken from Mortimer
+    skullofratha = 99,
+    giantsmithhammer = 100,
+    JoiningtheExplorers = 118,
+    TheIceDelivery = 102,
+    TheButterflyHunt = 103,
+    ThePlantCollection = 104,
+    TheLizardUrn = 105,
+    TheBonelordSecret = 106,
+    TheOrcPowder = 107,
+    TheElvenPoetry = 108,
+    TheMemoryStone = 109,
+    TheRuneWritings = 117,
+    TheEctoplasm = 111,
+    TheSpectralDress = 112,
+    TheSpectralStone = 113,
+    TheAstralPortals = 114,
+    TheIslandofDragons = 115,
+    TheIceMusic = 116
+  },
+  TravellingTrader = {
+    Mission01 = 101,
+    Mission02 = 102,
+    Mission03 = 103,
+    Mission04 = 104,
+    Mission05 = 105,
+    Mission06 = 106,
+    Mission07 = 107,
+    packageDoor = 108
+  },
+  DjinnWar = {
+    Faction = {
+      Greeting = 50717,
+      Marid = 50718,
+      Efreet = 50719
+    },
 
 		RecievedLamp = 50720,
 
-		-- blue djinn
-		MaridFaction = {
-			Start = 110,
-			Mission01 = 111,
-			Mission02 = 112,
-			RataMari = 113,
-			Mission03 = 114,
-			DoorToLamp = 115,
-			DoorToEfreetTerritory = 116
-		},
-		-- green djinn
-		EfreetFaction = {
-			Start = 120,
-			Mission01 = 121,
-			Mission02 = 122,
-			Mission03 = 123,
-			DoorToLamp = 124,
-			DoorToMaridTerritory = 125
-		}
-	},
-	VampireHunter = {
-		Rank = 402
-	},
-	BigfootBurden = {
-		QuestLine = 900,
-		Test = 901,
-		Shooting = 902,
-
-		MelodyTone1 = 904,
-		MelodyTone2 = 905,
-		MelodyTone3 = 906,
-		MelodyTone4 = 907,
-		MelodyTone5 = 908,
-		MelodyTone6 = 909,
-		MelodyTone7 = 910,
+    -- blue djinn
+    MaridFaction = {
+      Start = 110,
+      Mission01 = 111,
+      Mission02 = 112,
+      RataMari = 113,
+      Mission03 = 114,
+      DoorToLamp = 115,
+      DoorToEfreetTerritory = 116
+    },
+    -- green djinn
+    EfreetFaction = {
+      Start = 120,
+      Mission01 = 121,
+      Mission02 = 122,
+      Mission03 = 123,
+      DoorToLamp = 124,
+      DoorToMaridTerritory = 125
+    }
+  },
+  VampireHunter = {
+    Rank = 402
+  },
+  BigfootBurden = {
+    QuestLine = 900,
+    Test = 901,
+    Shooting = 902,
+    QuestLineComplete = 903,
+    MelodyTone1 = 904,
+    MelodyTone2 = 905,
+    MelodyTone3 = 906,
+    MelodyTone4 = 907,
+    MelodyTone5 = 908,
+    MelodyTone6 = 909,
+    MelodyTone7 = 910,
 
 		MelodyStatus = 911,
 
@@ -95,9 +200,10 @@ Storage = {
 		MushroomCount = 940,
 		MushroomDiggerTimeout = 941,
 
-		MissionMatchmaker = 942,
-		MatchmakerStatus = 943,
-		MatchmakerTimeout = 944,
+    MissionMatchmaker = 942,
+    MatchmakerStatus = 943,
+    MatchmakerIdNeeded = 963,
+    MatchmakerTimeout = 944,
 
 		MissionTinkersBell = 945,
 		GolemCount = 946,
@@ -116,110 +222,112 @@ Storage = {
 		Warzone2Access = 956,
 		Warzone3Access = 957,
 
-		Warzone1Reward = 958,
-		Warzone2Reward = 959,
-		Warzone3Reward = 960
-	},
-	TheirMastersVoice = {
-		SlimeGobblerTimeout = 984,
-		SlimeGobblerReceived = 985
-	},
-	KosheiTheDeathless = {
-		RewardDoor = 3066
-	},
-	ElementalSphere = {
-		QuestLine = 10000,
-		BossStorage = 10001,
-		MachineGemCount = 10002
-	},
-	GravediggerOfDrefia = {
-		-- Just numbered the storages by the order they are used in the quest
-		-- should be renamed to the correct mission names etc.
-		QuestStart = 9990,
-		Mission01 = 9991,
-		Mission02 = 9992,
-		Mission03 = 9993,
-		Mission04 = 9994,
-		Mission05 = 9995,
-		Mission06 = 9996,
-		Mission07 = 9997,
-		Mission08 = 9998,
-		Mission09 = 9999,
-		Mission10 = 9950,
-		Mission11 = 9951,
-		Mission12 = 9952,
-		Mission13 = 9953,
-		Mission14 = 9954,
-		Mission15 = 9955,
-		Mission16 = 9956,
-		Mission17 = 9957,
-		Mission18 = 9958,
-		Mission19 = 9959,
-		Mission20 = 9960,
-		Mission21 = 9961,
-		Mission22 = 9962,
-		Mission23 = 9963,
-		Mission24 = 9964,
-		Mission25 = 9965,
-		Mission26 = 9966,
-		Mission27 = 9967,
-		Mission28 = 9968,
-		Mission29 = 9969,
-		Mission30 = 9970,
-		Mission31 = 9971,
-		Mission32 = 9972,
-		Mission32a = 9973,
-		Mission32b = 9974,
-		Mission33 = 9975,
-		Mission34 = 9976,
-		Mission35 = 9977,
-		Mission36 = 9978,
-		Mission36a = 9979,
-		Mission37 = 9980,
-		Mission38 = 9981,
-		Mission38a = 9982,
-		Mission38b = 9983,
-		Mission38c = 9984,
-		Mission39 = 9985,
-		Mission40 = 9986,
-		Mission41 = 9987,
-		Mission42 = 9988,
-		Mission43 = 9989,
-		Mission44 = 9920,
-		Mission45 = 9921,
-		Mission46 = 9922,
-		Mission47 = 9923,
-		Mission48 = 9924,
-		Mission49 = 9925,
-		Mission50 = 9926,
-		Mission51 = 9927,
-		Mission52 = 9928,
-		Mission53 = 9929,
-		Mission54 = 9930,
-		Mission55 = 9931,
-		Mission56 = 9932,
-		Mission57 = 9933,
-		Mission58 = 9934,
-		Mission59 = 9935,
-		Mission60 = 9936,
-		Mission61 = 9937,
-		Mission62 = 9938,
-		Mission63 = 9939,
-		Mission64 = 9940,
-		Mission65 = 9941,
-		Mission66 = 9942,
-		Mission67 = 9943,
-		Mission68 = 9944,
-		Mission69 = 9945,
-		Mission70 = 9946,
-		Mission71 = 9947,
-		Mission72 = 9948,
-		Mission73 = 9949,
-		Mission74 = 9876
-	},
-	Oramond = {
-		QuestLine = 10060,
-		VotingPoints = 10061,
+    Warzone1Reward = 958,
+    Warzone2Reward = 959,
+    Warzone3Reward = 960,
+    bossKills = 961,
+    openGoldenFruits = 962
+  },
+  TheirMastersVoice = {
+    SlimeGobblerTimeout = 984,
+    SlimeGobblerReceived = 985
+  },
+  KosheiTheDeathless = {
+    RewardDoor = 3066
+  },
+  ElementalSphere = {
+    QuestLine = 10000,
+    BossStorage = 10001,
+    MachineGemCount = 10002
+  },
+  GravediggerOfDrefia = {
+    -- Just numbered the storages by the order they are used in the quest
+    -- should be renamed to the correct mission names etc.
+    QuestStart = 9990,
+    Mission01 = 9991,
+    Mission02 = 9992,
+    Mission03 = 9993,
+    Mission04 = 9994,
+    Mission05 = 9995,
+    Mission06 = 9996,
+    Mission07 = 9997,
+    Mission08 = 9998,
+    Mission09 = 9999,
+    Mission10 = 9950,
+    Mission11 = 9951,
+    Mission12 = 9952,
+    Mission13 = 9953,
+    Mission14 = 9954,
+    Mission15 = 9955,
+    Mission16 = 9956,
+    Mission17 = 9957,
+    Mission18 = 9958,
+    Mission19 = 9959,
+    Mission20 = 9960,
+    Mission21 = 9961,
+    Mission22 = 9962,
+    Mission23 = 9963,
+    Mission24 = 9964,
+    Mission25 = 9965,
+    Mission26 = 9966,
+    Mission27 = 9967,
+    Mission28 = 9968,
+    Mission29 = 9969,
+    Mission30 = 9970,
+    Mission31 = 9971,
+    Mission32 = 9972,
+    Mission32a = 9973,
+    Mission32b = 9974,
+    Mission33 = 9975,
+    Mission34 = 9976,
+    Mission35 = 9977,
+    Mission36 = 9978,
+    Mission36a = 9979,
+    Mission37 = 9980,
+    Mission38 = 9981,
+    Mission38a = 9982,
+    Mission38b = 9983,
+    Mission38c = 9984,
+    Mission39 = 9985,
+    Mission40 = 9986,
+    Mission41 = 9987,
+    Mission42 = 9988,
+    Mission43 = 9989,
+    Mission44 = 9920,
+    Mission45 = 9921,
+    Mission46 = 9922,
+    Mission47 = 9923,
+    Mission48 = 9924,
+    Mission49 = 9925,
+    Mission50 = 9926,
+    Mission51 = 9927,
+    Mission52 = 9928,
+    Mission53 = 9929,
+    Mission54 = 9930,
+    Mission55 = 9931,
+    Mission56 = 9932,
+    Mission57 = 9933,
+    Mission58 = 9934,
+    Mission59 = 9935,
+    Mission60 = 9936,
+    Mission61 = 9937,
+    Mission62 = 9938,
+    Mission63 = 9939,
+    Mission64 = 9940,
+    Mission65 = 9941,
+    Mission66 = 9942,
+    Mission67 = 9943,
+    Mission68 = 9944,
+    Mission69 = 9945,
+    Mission70 = 9946,
+    Mission71 = 9947,
+    Mission72 = 9948,
+    Mission73 = 9949,
+    Mission74 = 9876
+  },
+  Oramond = {
+    QuestLine = 10060,
+    VotingPoints = 10061,
 
 		MissionToTakeRoots = 20060,
 		HarvestedRootCount = 20061,
@@ -329,9 +437,10 @@ Storage = {
 		-- Wizard-outfit Quest
 		WizardAddon = 12066,
 
-		-- Pirate-outfit Quest
-		PirateSabreAddon = 50002,
-		PirateHatAddon = 22034,
+    -- Pirate-outfit Quest
+    PirateBaseOutfit = 50003,
+    PirateSabreAddon = 50002,
+    PirateHatAddon = 22034,
 
 		-- Assassin Outfit
 		AssassinBaseOutfit = 50080,
@@ -574,125 +683,129 @@ Storage = {
 		Rank = 12460,
 		Door = 12461,
 
-		TravelCarlin = 251,
-		TravelEdron = 252,
-		TravelVenore = 253,
-		TravelCormaya = 254
-	},
-	thievesGuild = {
-		Quest = 12501,
-		Mission01 = 12502,
-		Mission02 = 12503,
-		Mission03 = 12504,
-		Mission04 = 12505,
-		Mission05 = 12506,
-		Mission06 = 12507,
-		Mission07 = 12508,
-		Mission08 = 12509,
-		Door = 12510,
-		Reward = 12513,
-		TheatreScript = 12514
-	},
-	CaptainHaba = 12540,
-	secretService = {
-		Quest = 12550,
-		TBIMission01 = 12551,
-		AVINMission01 = 12552,
-		CGBMission01 = 12553,
-		TBIMission02 = 12554,
-		AVINMission02 = 12555,
-		CGBMission02 = 12556,
-		TBIMission03 = 12557,
-		AVINMission03 = 12558,
-		CGBMission03 = 12559,
-		TBIMission04 = 12560,
-		AVINMission04 = 12561,
-		CGBMission04 = 12562,
-		TBIMission05 = 12563,
-		AVINMission05 = 12564,
-		CGBMission05 = 12565,
-		TBIMission06 = 12566,
-		AVINMission06 = 12567,
-		CGBMission06 = 12568,
-		Mission07 = 12569,
-		RottenTree = 12578
-	},
-	hiddenCityOfBeregar = {
-		DefaultStart = 12600,
-		WayToBeregar = 12601,
-		OreWagon = 12602,
-		GoingDown = 12603,
-		JusticeForAll = 12604,
-		GearWheel = 12605,
-		SweetAsChocolateCake = 12606,
-		RoyalRescue = 12607,
-		TheGoodGuard = 12608,
-		PythiusTheRotten = 12609,
-		DoorNorthMine = 12610,
-		DoorWestMine = 12611,
-		DoorSouthMine = 12612,
-		BrownMushrooms = 12613
-	},
-	TibiaTales = {
-		DefaultStart = 12650,
-		ultimateBoozeQuest = 12651,
-		AgainstTheSpiderCult = 12652,
-		AnInterestInBotany = 12653,
-		AnInterestInBotanyChest = 12654,
-		IntoTheBonePit = 3938,
-		TheExterminator = 3939,
-		RestInHallowedGround = {
-			Questline = 3940,
-			HolyWater = 3941,
-			Graves = {
-				Grave1 = 3942,
-				Grave2 = 3943,
-				Grave3 = 3944,
-				Grave4 = 3945,
-				Grave5 = 3946,
-				Grave6 = 3947,
-				Grave7 = 3948,
-				Grave8 = 3949,
-				Grave9 = 3950,
-				Grave10 = 3951,
-				Grave11 = 3952,
-				Grave12 = 3953,
-				Grave13 = 3954,
-				Grave14 = 3955,
-				Grave15 = 3956,
-				Grave16 = 3957
-			}
-		}
-	},
-	TheShatteredIsles = {
-		DefaultStart = 12700,
-		TheGovernorDaughter = 12701,
-		TheErrand = 12702,
-		AccessToMeriana = 12703,
-		APoemForTheMermaid = 12704,
-		ADjinnInLove = 12705,
-		AccessToLagunaIsland = 12706,
-		AccessToGoroma = 12707,
-		Shipwrecked = 12708,
-		DragahsSpellbook = 12709,
-		TheCounterspell = 12710
-	},
-	SearoutesAroundYalahar = {
-		TownsCounter = 12800,
-		AbDendriel = 12801,
-		Darashia = 12802,
-		Venore = 12803,
-		Ankrahmun = 12804,
-		PortHope = 12805,
-		Thais = 12806,
-		LibertyBay = 12807,
-		Carlin = 12808,
-	},	
-	KillingInTheNameOf = {
-		LugriNecromancers = 50000,
-		LugriNecromancerCount = 65050,
-		BudrikMinos = 50001,
-		BudrikMinosCount = 65049,
+    TravelCarlin = 251,
+    TravelEdron = 252,
+    TravelVenore = 253,
+    TravelCormaya = 254
+  },
+  thievesGuild = {
+    Quest = 12501,
+    Mission01 = 12502,
+    Mission02 = 12503,
+    Mission03 = 12504,
+    Mission04 = 12505,
+    Mission05 = 12506,
+    Mission06 = 12507,
+    Mission07 = 12508,
+    Mission08 = 12509,
+    Door = 12510,
+    Reward = 12513,
+    TheatreScript = 12514
+  },
+  CaptainHaba = 12540,
+  secretService = {
+    Quest = 12550,
+    TBIMission01 = 12551,
+    AVINMission01 = 12552,
+    CGBMission01 = 12553,
+    TBIMission02 = 12554,
+    AVINMission02 = 12555,
+    CGBMission02 = 12556,
+    TBIMission03 = 12557,
+    AVINMission03 = 12558,
+    CGBMission03 = 12559,
+    TBIMission04 = 12560,
+    AVINMission04 = 12561,
+    CGBMission04 = 12562,
+    TBIMission05 = 12563,
+    AVINMission05 = 12564,
+    CGBMission05 = 12565,
+    TBIMission06 = 12566,
+    AVINMission06 = 12567,
+    CGBMission06 = 12568,
+    Mission07 = 12569,
+    RottenTree = 12578
+  },
+  hiddenCityOfBeregar = {
+    DefaultStart = 12600,
+    WayToBeregar = 12601,
+    OreWagon = 12602,
+    GoingDown = 12603,
+    JusticeForAll = 12604,
+    GearWheel = 12605,
+    SweetAsChocolateCake = 12606,
+    RoyalRescue = 12607,
+    TheGoodGuard = 12608,
+    PythiusTheRotten = 12609,
+    DoorNorthMine = 12610,
+    DoorWestMine = 12611,
+    DoorSouthMine = 12612,
+    BrownMushrooms = 12613
+  },
+  TibiaTales = {
+    DefaultStart = 12650,
+    ultimateBoozeQuest = 12651,
+    AgainstTheSpiderCult = 12652,
+    AnInterestInBotany = 12653,
+    AnInterestInBotanyChest = 12654,
+    AritosTask = 12690,
+    ToAppeaseTheMightyQuest = 13330,
+    IntoTheBonePit = 3938,
+    TheExterminator = 3939,
+    TrollSabotage = 2000000,
+
+    RestInHallowedGround = {
+      Questline = 3940,
+      HolyWater = 3941,
+      Graves = {
+        Grave1 = 3942,
+        Grave2 = 3943,
+        Grave3 = 3944,
+        Grave4 = 3945,
+        Grave5 = 3946,
+        Grave6 = 3947,
+        Grave7 = 3948,
+        Grave8 = 3949,
+        Grave9 = 3950,
+        Grave10 = 3951,
+        Grave11 = 3952,
+        Grave12 = 3953,
+        Grave13 = 3954,
+        Grave14 = 3955,
+        Grave15 = 3956,
+        Grave16 = 3957
+      }
+    }
+  },
+  TheShatteredIsles = {
+    DefaultStart = 12700,
+    TheGovernorDaughter = 12701,
+    TheErrand = 12702,
+    AccessToMeriana = 12703,
+    APoemForTheMermaid = 12704,
+    ADjinnInLove = 12705,
+    AccessToLagunaIsland = 12706,
+    AccessToGoroma = 12707,
+    Shipwrecked = 12708,
+    DragahsSpellbook = 12709,
+    TheCounterspell = 12710
+  },
+  SearoutesAroundYalahar = {
+    TownsCounter = 12800,
+    AbDendriel = 12801,
+    Darashia = 12802,
+    Venore = 12803,
+    Ankrahmun = 12804,
+    PortHope = 12805,
+    Thais = 12806,
+    LibertyBay = 12807,
+    Carlin = 12808,
+  },
+  KillingInTheNameOf = {
+    LugriNecromancers = 50000,
+    LugriNecromancerCount = 65050,
+    BudrikMinos = 50001,
+    BudrikMinosCount = 65049,
 
 		MissionTiquandasRevenge = 22222,
 		TiquandasRevengeTeleport = 22555,
@@ -821,12 +934,14 @@ Storage = {
 		WhisperMoss = 50033,
 		OldParchment = 50034,
 
-		DragahsSpellbook = 50148
-	},
-	PitsOfInferno = {
-		ShortcutHub = 8819,
-		ShortcutLevers = 8818,
-		Pumin = 50096,
+    DragahsSpellbook = 50148,
+
+    StealFromThieves = 19910
+  },
+  PitsOfInferno = {
+    ShortcutHub = 8819,
+    ShortcutLevers = 8818,
+    Pumin = 50096,
 
 		WeaponReward = 10544,
 
@@ -919,7 +1034,7 @@ Storage = {
 		souleaterUse = 165167,
 		ghostUse = 165168
 	},
-		
+
 	SeaOfLightQuest = {
 		Questline = 50250,
 		Mission1 = 50251,
@@ -996,29 +1111,65 @@ Storage = {
 }
 
 GlobalStorage = {
-	FuryGates = 100,
-	TheirMastersVoice = {
-		CurrentServantWave = 984,
-		ServantsKilled = 985
-	},
-	InServiceOfYalahar = {
-		LastFight = 982,
-		WarGolemsMachine1 = 23700,
-		WarGolemsMachine2 = 23701
-	},
-	Yakchal = 987,
-	PitsOfInfernoLevers = 1000,
-	Warzones = 3143,
-	Weeper = 3144,
-	Versperoth = {
-		Battle = 3147,
-		Health = 3148
-	},
-	WrathOfTheEmperor = {
-		Light01 = 8018,
-		Light02 = 8019,
-		Light03 = 8020,
-		Light04 = 8021,
+  FaunWorldChange = 48814,
+  FuryGates = 100,
+  TheirMastersVoice = {
+    CurrentServantWave = 984,
+    ServantsKilled = 985
+  },
+  Feroxa = {
+    Chance = 566039,
+    Active = 566040
+  },
+  HeroRathleton = {
+    FirstMachines = 566079,
+    SecondMachines = 566080,
+    ThirdMachines = 566081,
+    FourthMachines = 566082,
+    DeepRunning = 566083,
+    HorrorRunning = 566084,
+    LavaRunning = 566085,
+    LavaCounter = 566086,
+    MaxxenRunning = 566087,
+    TentacleWave = 566088,
+    DevourerWave = 566089,
+    GloothWave = 566090,
+    LavaChange = 566091
+  },
+  ForgottenKnowledge = {
+    TenebrisTimer = 566093,
+    ActiveTree = 566095,
+    MechanismGolden = 566096,
+    MechanismDiamond = 566097,
+    GoldenServant = 566098,
+    DiamondServant = 566099,
+    AstralPowerCounter = 566100,
+    AstralGlyph = 566101,
+    LloydTimer = 566102,
+    ThornKnightTimer = 566103,
+    DragonkingTimer = 566104,
+    HorrorTimer = 566105,
+    TimeGuardianTimer = 566106,
+    LastLoreTimer = 566107
+  },
+  InServiceOfYalahar = {
+    LastFight = 982,
+    WarGolemsMachine1 = 23700,
+    WarGolemsMachine2 = 23701
+  },
+  Yakchal = 987,
+  PitsOfInfernoLevers = 1000,
+  Warzones = 3143,
+  Weeper = 3144,
+  Versperoth = {
+    Battle = 3147,
+    Health = 3148
+  },
+  WrathOfTheEmperor = {
+    Light01 = 8018,
+    Light02 = 8019,
+    Light03 = 8020,
+    Light04 = 8021,
 
 		Bosses = {
 			Fury = 3189,

--- a/data/modules/scripts/gamestore/gamestore.lua
+++ b/data/modules/scripts/gamestore/gamestore.lua
@@ -1,520 +1,2623 @@
+--[[
+  Items have been updated so that if the offer type is not one of the types: OFFER_TYPE_OUTFIT, OFFER_TYPE_OUTFIT_ADDON,
+  OFFER_TYPE_MOUNT, OFFER_TYPE_NAMECHANGE, OFFER_TYPE_SEXCHANGE, OFFER_TYPE_PROMOTION, OFFER_TYPE_EXPBOOST,
+  OFFER_TYPE_PREYSLOT, OFFER_TYPE_PREYBONUS, OFFER_TYPE_TEMPLE, OFFER_TYPE_BLESSINGS, OFFER_TYPE_PREMIUM,
+  OFFER_TYPE_ALLBLESSINGS (it was not a non-item) then:
+  1) If the offer's name didn't exist in items.xml then the offer has been removed.
+    These items were removed from the shop because the name didn't exist in items.xml
+    [ "Alchemistic Scales", "Alchemist Table", "Pile of Alchemist Books", "Alchemist Cup Board", "Torch of Change", "Ferumbras Bust", "Queen Eloise Bust", "Arrival At Thais Painting", "Tibia Street Painting", "Ferumbras Portrait", "SupremeHealth Potion", "Health Keg", "Strong Health Keg", "Great Health Keg", "Ultimate Health Keg", "Supreme Health Keg", "Mana Keg", "Strong Mana Keg", "Great Mana Keg", "Ultimate Mana Keg", "Ultimate Spirit Keg", "Disintegrate Rune", "Paralyse Rune", "Alchemistic Scales", "Alchemist Table", "Pile of Alchemist Books", "Alchemist Cup Board", "Torch of Change", "Ferumbras Bust", "Queen Eloise Bust", "Arrival At Thais Painting", "Tibia Street Painting", "Ferumbras Portrait", "Demon Pit", "Venoream Table Clock", "StoneTiles", "Bath Tube", "Daily Reward Shrine", "Health Cask", "Strong Health Cask", "Great Health Cask", "Ultimate Health Cask", "Supreme Health Cask", "Mana Cask", "Strong Mana Cask", "Great Mana Cask", "Ultimate Mana Cask", "Great Spirit Cask", "Ultimate Spirit Cask", "Skull Lamp", "Fish Tank", "Lit Protectress Lamp", "Lit Predator Lamp", "LordlyTapestry", "All-Seeing Tapestry", "Gold Pounch" ]
+  2) If the offer's name did exist in items.xml then the thingId of the offer has been updated
+     so that it matches the item id in items.xml.
+]]
+
 -- Parser
 dofile('data/modules/scripts/gamestore/init.lua')
 -- Config
-GameStore.Categories = {
-	{
-		name = "New Products",
-		state = GameStore.States.STATE_NONE,
-		description = "Check out this category for the latest additions to the Store!",
-		icons = {"Category_NewProducts.png"},
-		rookgaard = true,
-		offers = {
-			{name = "Alchemistic Cabinet", thingId = 31192, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 100, icons = {"Product_HouseEquipment_alchemisticcabinet.png"}},
-			{name = "Alchemistic Bookstand", thingId = 31211, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 100, icons = {"Product_HouseEquipment_alchemisticbookstand.png"}},
-			{name = "Alchemistic Chair", thingId = 31258, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 50, icons = {"Product_HouseEquipment_alchemisticchair.png"}},
-			{name = "Alchemistic Scales", thingId = 31215, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 120, icons = {"Product_HouseEquipment_alchemisticscales.png"}},
-			{name = "Alchemist Table", thingId = 31194, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 80, icons = {"Product_HouseEquipment_alchemistictable.png"}},
-			{name = "Pile of Alchemist Books", thingId = 31219, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 120, icons = {"Product_HouseEquipment_pileofalchemisticbooks.png"}},
-			{name = "Alchemist Cup Board", thingId = 31221, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 50, icons = {"Product_HouseEquipment_alchemisticcupboard.png"}},
-			{name = "Light of Change", thingId = 31201, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 120, icons = {"Product_HouseEquipment_lightofchange.png"}},
-			{name = "Torch of Change", thingId = 31207, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 120, icons = {"Product_HouseEquipment_torchofchange.png"}},
-			{name = "Ferumbras Bust", thingId = 31305, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 70, icons = {"Product_HouseEquipment_ferumbrasbust.png"}},
-			{name = "Queen Eloise Bust", thingId = 31307, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 50, icons = {"Product_HouseEquipment_queeneloisebust.png"}},
-			{name = "King Tibianus Bust", thingId = 31309, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 50, icons = {"Product_HouseEquipment_kingtibianusbust.png"}},
-			{name = "Arrival At Thais Painting", thingId = 31226, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 50, icons = {"Product_HouseEquipment_arrivalatthaispainting.png"}},
-			{name = "Tibia Street Painting", thingId = 31228, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 100, icons = {"Product_HouseEquipment_tibiastreetspainting.png"}},
-			{name = "Ferumbras Portrait", thingId = 31230, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 100, icons = {"Product_HouseEquipment_ferumbrasportrait.png"}},
-		}
-	},
-	
-		{
-		name = "Premium Time",
-		state = GameStore.States.STATE_SALVE,
-		rookgaard = true,
-		icons = {"Category_PremiumTime.png"},
-		offers = {
-			{name = "30 Days of Premium Time", price = 250, state = GameStore.States.STATE_SALE, validUntil = 30, thingId = 30, type = GameStore.OfferTypes.OFFER_TYPE_PREMIUM, icons = {"Product_PremiumTime30.png"}, description = "Premium Account for 30 days."},
-			{name = "90 Days of Premium Time", price = 400, state = GameStore.States.STATE_SALE, validUntil = 30, thingId = 90, type = GameStore.OfferTypes.OFFER_TYPE_PREMIUM, icons = {"Product_PremiumTime90.png"}, description = "Premium Account for 90 days."},
-			{name = "180 Days of Premium Time", price = 700, state = GameStore.States.STATE_SALE, validUntil = 30, thingId = 180, type = GameStore.OfferTypes.OFFER_TYPE_PREMIUM, icons = {"Product_PremiumTime180.png"}, description = "Premium Account for 180 days."},
-			{name = "360 Days of Premium Time", price = 1000, state = GameStore.States.STATE_SALE, validUntil = 30, thingId = 360, type = GameStore.OfferTypes.OFFER_TYPE_PREMIUM, icons = {"Product_PremiumTime360.png"}, description = "Premium Account for 180 days."}
-		}
-	},
-	
-	{
-		name = "Extra Services",
-		state = GameStore.States.STATE_NONE,
-		description = "Buy an Extra Service to transfer a character to another game world or to change your character's name or sex.",
-		icons = {"Category_ExtraServices.png"},
-		rookgaard = true,
-		offers = {
-			{name = "Character Name Change", type = GameStore.OfferTypes.OFFER_TYPE_NAMECHANGE, price = 250, icons = {"namechanger.png"}},
-			{name = "Character Sex Change", type = GameStore.OfferTypes.OFFER_TYPE_SEXCHANGE, price = 120, icons = {"sexchanger.png"}},
-		}
-	},
-	
-	{
-		name = "Blessings",
-		state = GameStore.States.STATE_NONE,
-		icons = {"Category_Blessings.png"},
-		rookgaard = true,
-		offers = {
-			{name = "All Regular Blessings", thingId = 1, type = GameStore.OfferTypes.OFFER_TYPE_ALLBLESSINGS, price = 30, icons = {"Product_Blessing_AllPvE.png"}},
-			{name = "Twist of Fate", thingId = 1, type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS, price = 2, icons = {"Product_Blessing_Fate.png"}},
-			{name = "The Wisdom of Solitude", thingId = 2, type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS, price = 5, icons = {"Product_Blessing_Solitude.png"}},
-			{name = "The Spark of the Phoenix", thingId = 3, type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS, price = 8, icons = {"Product_Blessing_Phoenix.png"}},
-			{name = "The Fire of the Suns", thingId = 4, type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS, price = 5, icons = {"Product_Blessing_Suns.png"}},
-			{name = "The Spiritual Shielding", thingId = 5, type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS, price = 5, icons = {"Product_Blessing_Shielding.png"}},
-			{name = "The Embrace of Tibia", thingId = 6, type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS, price = 5, icons = {"Product_Blessing_Tibia.png"}},
-			{name = "Heart of the Mountain", thingId = 7, type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS, price = 10, icons = {"Product_Blessing_HeartOfTheMountain.png"}},
-			{name = "Blood of the Mountain", thingId = 8, type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS, price = 10, icons = {"Product_Blessing_BloodOfTheMountain.png"}},
-		}
-	},
-	
-	{
-		name = "Potions & Kegs",
-		state = GameStore.States.STATE_NONE,
-		description = "Buy potions to refil your character's hit points and mana.",
-		rookgaard = true,
-		icons = {"Category_Potions.png"},
-		offers = {
-			{name = "Health Potion", thingId = 7618, count = 125, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 4, icons = {"Product_Potion_Health_potion.png"}},
-			{name = "Health Potion", thingId = 7618, count = 300, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 10, icons = {"Product_Potion_Health_potion.png"}},
-			{name = "Strong Health Potion", thingId = 7588, count = 100, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 7, icons = {"Product_Potion_Strong_health_potion.png"}},
-			{name = "Strong Health Potion", thingId = 7588, count = 300, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 18, icons = {"Product_Potion_Strong_health_potion.png"}},
-			{name = "Great Health Potion", thingId = 7591, count = 100, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 13, icons = {"Product_Potion_Great_health_potion.png"}},
-			{name = "Great Health Potion", thingId = 7591, count = 300, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 34, icons = {"Product_Potion_Great_health_potion.png"}},
-			{name = "Ultimate Health Potion", thingId = 8473, count = 100, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 22, icons = {"Product_Potion_ultimate_health_potion.png"}},
-			{name = "Ultimate Health Potion", thingId = 8473, count = 300, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 55, icons = {"Product_Potion_ultimate_health_potion.png"}},
-			{name = "Supreme Health Potion", thingId = 26031, count = 100, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 36, icons = {"Product_Potion_Supreme_health_potion.png"}},
-			{name = "Supreme Health Potion", thingId = 26031, count = 300, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 90, icons = {"Product_Potion_Supreme_health_potion.png"}},
-			{name = "Mana Potion", thingId = 7620, count = 125, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 4, icons = {"Product_Potion_Mana_Potion.png"}},
-			{name = "Mana Potion", thingId = 7620, count = 300, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 10, icons = {"Product_Potion_Mana_Potion.png"}},
-			{name = "Health Keg", thingId = 28579, count = 500, type = GameStore.OfferTypes.OFFER_TYPE_ITEM, price = 23, icons = {"Product_Potion_HealthPotionKeg.png"}},
-			{name = "Strong Health Keg", type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 15, thingId = 28580, count = 500, icons = {"Strong_Health_Keg.png"}},
-			{name = "Great Health Keg", type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 15, thingId = 28581, count = 500, icons = {"Strong_Health_Keg.png"}},
-			{name = "Ultimate Health Keg", type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 15, thingId = 28582, count = 500, icons = {"Ultimate_Health_Keg.png"}},
-			{name = "Supreme Health Keg", type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 15, thingId = 28583, count = 500,  icons = {"Supreme_Health_Keg.png"}},						   
-			{name = "Mana Keg", type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 15, thingId = 28584, count = 500, icons = {"Mana_Keg.png"}},
-			{name = "Strong Mana Keg", type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 15, thingId = 28585, count = 500, icons = {"Strong_Mana_Keg.png"}},
-			{name = "Great Mana Keg", type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 15, thingId = 28586, count = 500, icons = {"Great_Mana_Keg.png"}},
-			{name = "Ultimate Mana Keg", type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 15, thingId = 28587, count = 500, icons = {"Ultimate_Mana_Keg.png"}},
-			{name = "Ultimate Spirit Keg", type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, price = 15, thingId = 28590, count = 500, icons = {"Ultimate_Spirit_Keg.png"}},
-		 }
-	},
+GameStore.Categories = { {
+   description = "Check out this category for the latest additions to the Store!",
+   icons = { "Category_NewProducts.png" },
+   name = "New Products",
+   offers = { {
+                count = 1,
+                icons = { "Product_HouseEquipment_alchemisticcabinet.png" },
+                name = "Alchemistic Cabinet",
+                price = 100,
+                id = 32020,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_alchemisticbookstand.png" },
+                name = "Alchemistic Bookstand",
+                price = 100,
+                id = 32031,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_alchemisticchair.png" },
+                name = "Alchemistic Chair",
+                price = 50,
+                id = 32018,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_lightofchange.png" },
+                name = "Light of Change",
+                price = 120,
+                id = 33174,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_kingtibianusbust.png" },
+                name = "King Tibianus Bust",
+                price = 50,
+                id = 32050,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              } },
+   rookgaard = true,
+   state = GameStore.States.STATE_NONE,
+ }, {
+   icons = { "Category_PremiumTime.png" },
+   name = "Premium Time",
+   offers = { {
+                description = "Premium Account for 30 days.",
+                icons = { "Product_PremiumTime30.png" },
+                name = "30 Days of Premium Time",
+                price = 250,
+                state = GameStore.States.STATE_SALE,
+                id = 30,
+                type = GameStore.OfferTypes.OFFER_TYPE_PREMIUM,
+                validUntil = 30
+              }, {
+                description = "Premium Account for 90 days.",
+                icons = { "Product_PremiumTime90.png" },
+                name = "90 Days of Premium Time",
+                price = 400,
+                state = GameStore.States.STATE_SALE,
+                id = 90,
+                type = GameStore.OfferTypes.OFFER_TYPE_PREMIUM,
+                validUntil = 30
+              }, {
+                description = "Premium Account for 180 days.",
+                icons = { "Product_PremiumTime180.png" },
+                name = "180 Days of Premium Time",
+                price = 700,
+                state = GameStore.States.STATE_SALE,
+                id = 180,
+                type = GameStore.OfferTypes.OFFER_TYPE_PREMIUM,
+                validUntil = 30
+              }, {
+                description = "Premium Account for 180 days.",
+                icons = { "Product_PremiumTime360.png" },
+                name = "360 Days of Premium Time",
+                price = 1000,
+                state = GameStore.States.STATE_SALE,
+                id = 360,
+                type = GameStore.OfferTypes.OFFER_TYPE_PREMIUM,
+                validUntil = 30
+              } },
+   rookgaard = true,
+   state = GameStore.States.STATE_SALVE,
+ }, {
+   description = "Buy an Extra Service to transfer a character to anothergame world or to change your character's name or sex.",
+   icons = { "Category_ExtraServices.png" },
+   name = "Extra Services",
+   offers = { {
+                description = "You must be in a protection zone to change your name. After entering your new name, you will be disconnected from the server. You must logout completely and login again using your account details in order to refresh your character list.",
+                icons = { "namechanger.png" },
+                name = "Character Name Change",
+                price = 250,
+                id = 65542,
+                type = GameStore.OfferTypes.OFFER_TYPE_NAMECHANGE,
+              }, {
+                description = "Use this to change the sex of your character. Changes apply immediately. You don't need to logout for changes to apply.",
+                icons = { "sexchanger.png" },
+                name = "Character Sex Change",
+                price = 120,
+                id = 65543,
+                type = GameStore.OfferTypes.OFFER_TYPE_SEXCHANGE,
+              } },
+   rookgaard = true,
+   state = GameStore.States.STATE_NONE,
+ }, {
+   icons = { "Category_Blessings.png" },
+   name = "Blessings",
+   offers = { {
+                icons = { "Product_Blessing_AllPvE.png" },
+                name = "All Regular Blessings",
+                price = 30,
+                id = 9,
+                type = GameStore.OfferTypes.OFFER_TYPE_ALLBLESSINGS,
+              }, {
+                icons = { "Product_Blessing_Fate.png" },
+                name = "Twist of Fate",
+                price = 2,
+                id = 1,
+                type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS,
+              }, {
+                icons = { "Product_Blessing_Solitude.png" },
+                name = "The Wisdom of Solitude",
+                price = 5,
+                id = 2,
+                type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS,
+              }, {
+                icons = { "Product_Blessing_Phoenix.png" },
+                name = "The Spark of the Phoenix",
+                price = 8,
+                id = 3,
+                type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS,
+              }, {
+                icons = { "Product_Blessing_Suns.png" },
+                name = "The Fire of the Suns",
+                price = 5,
+                id = 4,
+                type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS,
+              }, {
+                icons = { "Product_Blessing_Shielding.png" },
+                name = "The Spiritual Shielding",
+                price = 5,
+                id = 5,
+                type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS,
+              }, {
+                icons = { "Product_Blessing_Tibia.png" },
+                name = "The Embrace of Tibia",
+                price = 5,
+                id = 6,
+                type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS,
+              }, {
+                icons = { "Product_Blessing_HeartOfTheMountain.png" },
+                name = "Heart of the Mountain",
+                price = 10,
+                id = 7,
+                type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS,
+              }, {
+                icons = { "Product_Blessing_BloodOfTheMountain.png" },
+                name = "Blood of the Mountain",
+                price = 10,
+                id = 8,
+                type = GameStore.OfferTypes.OFFER_TYPE_BLESSINGS,
+              } },
+   rookgaard = true,
+   state = GameStore.States.STATE_NONE,
+ }, {
+   description = "Buy potions to refil your character's hit points and mana.",
+   icons = { "Category_Potions.png" },
+   name = "Potions & Kegs",
+   offers = { {
+                count = 125,
+                icons = { "Product_Potion_Health_potion.png" },
+                name = "Health Potion",
+                price = 4,
+                id = 7618,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 300,
+                icons = { "Product_Potion_Health_potion.png" },
+                name = "Health Potion",
+                price = 10,
+                id = 7618,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 100,
+                icons = { "Product_Potion_Strong_health_potion.png" },
+                name = "Strong Health Potion",
+                price = 7,
+                id = 7588,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 300,
+                icons = { "Product_Potion_Strong_health_potion.png" },
+                name = "Strong Health Potion",
+                price = 18,
+                id = 7588,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 100,
+                icons = { "Product_Potion_Great_health_potion.png" },
+                name = "Great Health Potion",
+                price = 13,
+                id = 7591,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 300,
+                icons = { "Product_Potion_Great_health_potion.png" },
+                name = "Great Health Potion",
+                price = 34,
+                id = 7591,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 100,
+                icons = { "Product_Potion_ultimate_health_potion.png" },
+                name = "Ultimate Health Potion",
+                price = 22,
+                id = 8473,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 300,
+                icons = { "Product_Potion_ultimate_health_potion.png" },
+                name = "Ultimate Health Potion",
+                price = 55,
+                id = 8473,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 300,
+                icons = { "Product_Potion_Supreme_health_potion.png" },
+                name = "Supreme Health Potion",
+                price = 90,
+                id = 26031,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 125,
+                icons = { "Product_Potion_Mana_Potion.png" },
+                name = "Mana Potion",
+                price = 4,
+                id = 7620,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 300,
+                icons = { "Product_Potion_Mana_Potion.png" },
+                name = "Mana Potion",
+                price = 10,
+                id = 7620,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              } },
+   rookgaard = true,
+   state = GameStore.States.STATE_NONE,
+ }, {
+   description = "Buy magically filled runes to unleash their energy when in need of it.",
+   icons = { "Category_Runes.png" },
+   name = "Runes",
+   offers = { {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Animate Dead Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes boughtin the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_AnimateDeadRune.png" },
+                name = "Animate Dead Rune",
+                price = 75,
+                id = 2316,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Avalanche Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone blockor a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_AvalancheRune.png" },
+                name = "Avalanche Rune",
+                price = 9,
+                id = 2274,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Chameleon Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level andmagic level.",
+                icons = { "Product_Rune_ChameleonRune.png" },
+                name = "Chameleon Rune",
+                price = 42,
+                id = 2291,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Convince Creature Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in theStore can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_ConvinceRune.png" },
+                name = "Convince Creature Rune",
+                price = 16,
+                id = 2290,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Cure Poison Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_CurePoisonRune.png" },
+                name = "Cure Poison Rune",
+                price = 13,
+                id = 2266,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Energy Bomb Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runesneed to fit the character's level and magic level.",
+                icons = { "Product_Rune_EnergyBombRune.png" },
+                name = "Energy Bomb Rune",
+                price = 32,
+                id = 2262,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Energy Field Runes'. Use themto unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. Forthis reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_EnergyFieldRune.png" },
+                name = "Energy Field Rune",
+                price = 8,
+                id = 2277,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Energy Wall Runes'. Use them to unleash their magical energy when in need of it.Note, characterswith a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_EnergyWallRune.png" },
+                name = "Energy Wall Rune",
+                price = 17,
+                id = 2279,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here youcan purchase a stack of '250 Explosion Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_ExplosionRune.png" },
+                name = "Explosion Rune",
+                price = 6,
+                id = 2313,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Fireball Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_FireballRune.png" },
+                name = "Fireball Rune",
+                price = 6,
+                id = 2302,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Fire Bomb Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase.For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_FireBombRune.png" },
+                name = "Fire Bomb Rune",
+                price = 23,
+                id = 2305,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Fire Field Runes'. Use them to unleash their magical energy when in need of it.Note, characterswith a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_FireFieldRune.png" },
+                name = "Fire Field Rune",
+                price = 6,
+                id = 2301,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here youcan purchase a stack of '250 Fire Wall Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_FireWallRune.png" },
+                name = "Fire Wall Rune",
+                price = 12,
+                id = 2303,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of 'Great Fireball Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_GreatFireBallRune.png" },
+                name = "Great Fireball Rune",
+                price = 9,
+                id = 2304,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Icicle Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zoneblock or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_IcicleRune.png" },
+                name = "Icicle Rune",
+                price = 6,
+                id = 2271,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Intense Healing Runes'. Use them to unleash their magical energy when in need ofit.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only beused by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_IntenseHealingRune.png" },
+                name = "Intense Healing Rune",
+                price = 19,
+                id = 2265,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Magic Wall Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_MagicWallRune.png" },
+                name = "Magic Wall Rune",
+                price = 23,
+                id = 2293,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Poison Bomb Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_PoisonBombRune.png" },
+                name = "Poison Bomb Rune",
+                price = 17,
+                id = 2286,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Poison Wall Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runesneed to fit the character's level and magic level.",
+                icons = { "Product_Rune_PoisonWallRune.png" },
+                name = "Poison Wall Rune",
+                price = 10,
+                id = 2289,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Soulfire Runes'. Use them to unleashtheir magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_SoulfireRune.png" },
+                name = "Soulfire Rune",
+                price = 9,
+                id = 2308,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Stone Shower Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes thatexceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magiclevel.",
+                icons = { "Product_Rune_StoneShowerRune.png" },
+                name = "Stone Shower Rune",
+                price = 7,
+                id = 2288,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Sudden Death Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_SuddenDeathRune.png" },
+                name = "Sudden Death Rune",
+                price = 22,
+                id = 2268,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Thunderstorm Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_ThunderstormRune.png" },
+                name = "Thunderstorm Rune",
+                price = 7,
+                id = 2315,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Ultimate Healing Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannotbuy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_UltimateHealingRune.png" },
+                name = "Ultimate Healing Rune",
+                price = 35,
+                id = 2273,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              }, {
+                count = 250,
+                description = "Here you can purchase a stack of '250 Wild Growth Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchaserunes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.",
+                icons = { "Product_Rune_WildGrowthRune.png" },
+                name = "Wild Growth Rune",
+                price = 32,
+                id = 2269,
+                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+              } },
+   rookgaard = true,
+   state = GameStore.States.STATE_NONE,
+ }, {
+   description = "Buy your character one or more of the fabolous Mountsoffered here.",
+   icons = { "Category_Mounts.png" },
+   name = "Mounts",
+   offers = { {
+                description = "Here you can purchase the Mount 'Cranium Spider' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_SkullSpider_v1.png" },
+                name = "Cranium Spider",
+                price = 690,
+                id = 116,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Cave Tarantula' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_SkullSpider_v2.png" },
+                name = "Cave Tarantula",
+                price = 690,
+                id = 117,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Snow Pelt' for your character. Riding on a mount isnot only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_SkullSpider_v3.png" },
+                name = "Gloom Widow",
+                price = 690,
+                id = 118,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Gloom Widow' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_UnicornFire.png" },
+                name = "Blazing Unicorn",
+                price = 870,
+                id = 113,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Artic Unicorn' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_UnicornRainbow.png" },
+                name = "Artic Unicorn",
+                price = 870,
+                id = 114,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Prismatic Unicorn' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_UnicornIce.png" },
+                name = "Prismatic Unicorn",
+                price = 870,
+                id = 115,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Armoured War Horse' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_ArmouredWarHorse.png" },
+                name = "Armoured War Horse",
+                price = 870,
+                id = 23,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Shadow Draptor' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_shadowdraptor.png" },
+                name = "Shadow Draptor",
+                price = 870,
+                id = 24,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Steelbeak' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_steelbeak.png" },
+                name = "Steelbeak",
+                price = 870,
+                id = 34,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you canpurchase the Mount 'Crimson Ray' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_crimsonray.png" },
+                name = "CrimsonRay",
+                price = 870,
+                id = 33,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Jungle Saurian' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Saurian_v1.png" },
+                name = "Jungle Saurian",
+                price = 750,
+                id = 110,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Ember Saurian' for your character. Riding on a mount is not only cool, but also gives yourcharacter a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Saurian_v2.png" },
+                name = "Ember Saurian",
+                price = 750,
+                id = 111,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Lagoon Saurian' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Saurian_v3.png" },
+                name = "Lagoon Saurian",
+                price = 750,
+                id = 112,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'GoldSphinx' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Sphinx_v1.png" },
+                name = "Gold Sphinx",
+                price = 750,
+                id = 107,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Emerald Sphinx' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Sphinx_v2.png" },
+                name = "Emerald Sphinx",
+                price = 750,
+                id = 108,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Shadow Sphinx' foryour character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Sphinx_v3.png" },
+                name = "Shadow Sphinx",
+                price = 750,
+                id = 109,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Jackalope' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_AntleredRabbit_v1.png" },
+                name = "Jackalope",
+                price = 870,
+                id = 103,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Dreadhare' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mountwill only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_AntleredRabbit_v2.png" },
+                name = "Dreadhare",
+                price = 870,
+                id = 104,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Wolpertinger' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_AntleredRabbit_v3.png" },
+                name = "Wolpertinger",
+                price = 870,
+                id = 105,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Ivory Fang' for your character. Riding on amount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_ivoryfang.png" },
+                name = "Ivory Fang",
+                price = 750,
+                id = 100,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Shadow Claw' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_ShadowClaw.png" },
+                name = "Shadow Claw",
+                price = 750,
+                id = 101,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Snow Pelt' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_SnowPelt.png" },
+                name = "Snow Pelt",
+                price = 750,
+                id = 102,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Swamp Snapper' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_SwampSnapper.png" },
+                name = "Swamp Snapper",
+                price = 690,
+                id = 95,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Mould Shell' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased itin the Store.",
+                icons = { "Product_Mount_MouldShell.png" },
+                name = "Mould Shell",
+                price = 690,
+                id = 96,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount'Reed Lurker' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_ReedLurker.png" },
+                name = "Reed Lurker",
+                price = 690,
+                id = 97,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Bloodcurl' for your character. Riding on a mount is not only cool, but also gives your character a speed boost.Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Bloodcurl.png" },
+                name = "Bloodcurl",
+                price = 720,
+                id = 92,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Leafscuttler' for yourcharacter. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Leafscuttler.png" },
+                name = "Leafscuttler",
+                price = 750,
+                id = 93,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Mouldpincer' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Mouldpincer.png" },
+                name = "Mouldpincer",
+                price = 750,
+                id = 91,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Nightdweller' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Nightdweller.png" },
+                name = "Nightdweller",
+                price = 870,
+                id = 88,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Frostflare' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Frostflare.png" },
+                name = "Frostflare",
+                price = 870,
+                id = 89,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Cinderhoof' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Cinderhoof.png" },
+                name = "Cinderhoof",
+                price = 870,
+                id = 90,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you canpurchase the Mount 'Slagsnare' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Slagsnare.png" },
+                name = "Slagsnare",
+                price = 780,
+                id = 84,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Nightstinger' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Nightstinger.png" },
+                name = "Nightstinger",
+                price = 780,
+                id = 85,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Razorcreep' for your character. Riding on a mount is not only cool, but also gives your character aspeed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Razorcreep.png" },
+                name = "Razorcreep",
+                price = 780,
+                id = 86,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Gorongra' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note:The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Gorongra.png" },
+                name = "Gorongra",
+                price = 720,
+                id = 81,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Noctungra' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Noctungra.png" },
+                name = "Noctungra",
+                price = 720,
+                id = 82,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Silverneck' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Silverneck.png" },
+                name = "Silverneck",
+                price = 720,
+                id = 83,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Sea Devil' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_SeaDevil.png" },
+                name = "Sea Devil",
+                price = 570,
+                id = 78,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Coralripper' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Coralripper.png" },
+                name = "Coralripper",
+                price = 570,
+                id = 79,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Plumfish' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Plumfish.png" },
+                name = "Plumfish",
+                price = 570,
+                id = 80,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Flitterkatzen' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Flitterkatzen.png" },
+                name = "Flitterkatzen",
+                price = 870,
+                id = 75,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Venompaw' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Venompaw.png" },
+                name = "Venompaw",
+                price = 870,
+                id = 76,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Batcat' for your character. Riding on amount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_BatCat.png" },
+                name = "Batcat",
+                price = 870,
+                id = 77,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Ringtail Waccoon' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will onlybe received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_RingtailWaccoon.png" },
+                name = "Ringtail Waccoon",
+                price = 750,
+                id = 68,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Night Waccoon' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_NightWaccoon.png" },
+                name = "Night Waccoon",
+                price = 750,
+                id = 69,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Emerald Waccoon' for your character. Riding on amount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_EmeraldWaccoon.png" },
+                name = "Emerald Waccoon",
+                price = 750,
+                id = 70,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Flying Divan' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be receivedby the character who purchased it in the Store.",
+                icons = { "Product_Mount_FlyingDivan.png" },
+                name = "Flying Divan",
+                price = 900,
+                id = 65,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Magic Carpet' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_MagicCarpet.png" },
+                name = "Magic Carpet",
+                price = 900,
+                id = 66,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Floating Kashmir' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_FloatingKashmir.png" },
+                name = "Floating Kashmir",
+                price = 900,
+                id = 67,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Shadow Hart' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_ShadowHart.png" },
+                name = "Shadow Hart",
+                price = 660,
+                id = 72,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Black Stag' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_BlackStag.png" },
+                name = "Black Stag",
+                price = 660,
+                id = 73,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Emperor Deer' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it inthe Store.",
+                icons = { "Product_Mount_EmperorDeer.png" },
+                name = "Emperor Deer",
+                price = 660,
+                id = 74,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Tundra Rambler' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_TundraRambler.png" },
+                name = "Tundra Rambler",
+                price = 750,
+                id = 62,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Highland Yak' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_HighlandYak.png" },
+                name = "Highland Yak",
+                price = 750,
+                id = 63,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Glacier Vagabond' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_GlacierVagabond.png" },
+                name = "Glacier Vagabond",
+                price = 750,
+                id = 64,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Golden Dragonfly' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_GoldenDragonfly.png" },
+                name = "Golden Dragonfly",
+                price = 600,
+                id = 59,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Steel Bee' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_SteelBee.png" },
+                name = "Steel Bee",
+                price = 600,
+                id = 60,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Copper Fly' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_CopperFly.png" },
+                name = "Copper Fly",
+                price = 600,
+                id = 61,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Doombringer' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Doombringer.png" },
+                name = "Doombringer",
+                price = 780,
+                id = 53,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Woodland Prince' for your character.Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_WoodlandPrince.png" },
+                name = "Woodland Prince",
+                price = 780,
+                id = 54,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Hailtorm Fury' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_HailstormFury.png" },
+                name = "Hailtorm Fury",
+                price = 780,
+                id = 55,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Siegebreaker' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only bereceived by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Siegebreaker.png" },
+                name = "Siegebreaker",
+                price = 690,
+                id = 56,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Poisonbane' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Poisonbane.png" },
+                name = "Poisonbane",
+                price = 690,
+                id = 57,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Hereyou can purchase the Mount 'Blackpelt' for your character. Riding on a mount is not only cool, butalso gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Blackpelt.png" },
+                name = "Blackpelt",
+                price = 690,
+                id = 58,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Nethersteed' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Nethersteed.png" },
+                name = "Nethersteed",
+                price = 900,
+                id = 50,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Tempest' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Tempest.png" },
+                name = "Tempest",
+                price = 900,
+                id = 51,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Flamesteed' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Flamesteed.png" },
+                name = "Flamesteed",
+                price = 900,
+                id = 47,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Tombstinger' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_Tombstinger.png" },
+                name = "Tombstinger",
+                price = 600,
+                id = 36,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Death Crawler' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_DeathCrawler.png" },
+                name = "Death Crawler",
+                price = 600,
+                id = 46,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Jade Pincer' for your character. Riding on amount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_JadePincer.png" },
+                name = "Jade Pincer",
+                price = 600,
+                id = 49,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Desert King' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received bythe character who purchased it in the Store.",
+                icons = { "Product_Mount_DesertKing.png" },
+                name = "Desert King",
+                price = 450,
+                id = 41,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Hereyou can purchase the Mount 'Jade Lion' for your character. Riding on a mount is not only cool, butalso gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.",
+                icons = { "Product_Mount_JadeLion.png" },
+                name = "Jade Lion",
+                price = 450,
+                id = 48,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              }, {
+                description = "Here you can purchase the Mount 'Winter king' for your character. Riding on a mount is not only cool, but also givesyour character a speed boost. Note: The Mount will only be received by the character who purchasedit in the Store.",
+                icons = { "Product_Mount_WinterKing.png" },
+                name = "Winter King",
+                price = 450,
+                id = 52,
+                type = GameStore.OfferTypes.OFFER_TYPE_MOUNT,
+              } },
+   rookgaard = true,
+   state = GameStore.States.STATE_NONE,
+ }, {
+   -- Base outfit has addon = 0 or no defined addon. By default addon is set to 0.
+   description = "Buy your character one more of the classy outfits offered here.",
+   icons = { "Category_Outfits.png" },
+   name = "Outfits",
+   offers = { {
+                addon = 3,
+                icons = { "Product_Outfit_SunPriest_Male_Full.png", "Product_Outfit_SunPriest_Female_Full.png" },
+                name = "Full Sun Priest Outfit",
+                price = 750,
+                sexId = {
+                  female = 1024,
+                  male = 1023
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_SunPriest_Male_Base.png", "Product_Outfit_SunPriest_Female_Base.png" },
+                name = "Sun Priest Outfit",
+                price = 570,
+                sexId = {
+                  female = 1024,
+                  male = 1023
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_SunPriest_Male_Addon1.png", "Product_Outfit_SunPriest_Female_Addon1.png" },
+                name = "Sun Priest Addon 1",
+                price = 120,
+                sexId = {
+                  female = 1024,
+                  male = 1023
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_SunPriest_Male_Addon2.png", "Product_Outfit_SunPriest_Female_Addon2.png" },
+                name = "Sun Priest Addon 2",
+                price = 120,
+                sexId = {
+                  female = 1024,
+                  male = 1023
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_Herbalist_Male_Full.png", "Product_Outfit_Herbalist_Female_Full.png" },
+                name = "Full Herbalist Outfit",
+                price = 750,
+                sexId = {
+                  female = 1020,
+                  male = 1021
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_Herbalist_Male_Base.png", "Product_Outfit_Herbalist_Female_Base.png" },
+                name = "Herbalist Outfit",
+                price = 570,
+                sexId = {
+                  female = 1020,
+                  male = 1021
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_Herbalist_Male_Addon1.png", "Product_Outfit_Herbalist_Female_Addon1.png" },
+                name = "Herbalist Addon 1",
+                price = 120,
+                sexId = {
+                  female = 1020,
+                  male = 1021
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_Herbalist_Male_Addon2.png", "Product_Outfit_Herbalist_Female_Addon2.png" },
+                name = "Herbalist Addon 2",
+                price = 120,
+                sexId = {
+                  female = 1020,
+                  male = 1021
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_Entrepreneur_Male_Full.png", "Product_Outfit_Entrepreneur_Female_Full.png" },
+                name = "Full Entrepreneur Outfit",
+                price = 750,
+                sexId = {
+                  female = 471,
+                  male = 472
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_Entrepreneur_Male_Base.png", "Product_Outfit_Entrepreneur_Female_Base.png" },
+                name = "Entrepreneur Outfit",
+                price = 570,
+                sexId = {
+                  female = 471,
+                  male = 472
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_Entrepreneur_Male_Addon1.png", "Product_Outfit_Entrepreneur_Female_Addon1.png" },
+                name = "Entrepreneur Addon 1",
+                price = 120,
+                sexId = {
+                  female = 471,
+                  male = 472
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_Entrepreneur_Male_Addon2.png", "Product_Outfit_Entrepreneur_Female_Addon2.png" },
+                name = "Entrepreneur Addon 2",
+                price = 120,
+                sexId = {
+                  female = 471,
+                  male = 472
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_TrophyHunter_Male_Full.png", "Product_Outfit_TrophyHunter_Female_Full.png" },
+                name = "Full Trophy Hunter Outfit",
+                price = 870,
+                sexId = {
+                  female = 900,
+                  male = 899
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_TrophyHunter_Male_Base.png", "Product_Outfit_TrophyHunter_Female_Base.png" },
+                name = "Trophy Hunter Outfit",
+                price = 690,
+                sexId = {
+                  female = 900,
+                  male = 899
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_TrophyHunter_Male_Addon1.png", "Product_Outfit_TrophyHunter_Female_Addon1.png" },
+                name = "Trophy Hunter Addon 1",
+                price = 120,
+                sexId = {
+                  female = 900,
+                  male = 899
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_TrophyHunter_Male_Addon2.png", "Product_Outfit_TrophyHunter_Female_Addon2.png" },
+                name = "Trophy Hunter Addon 2",
+                price = 120,
+                sexId = {
+                  female = 900,
+                  male = 899
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                icons = { "Product_Outfit_RetroCitizen_Male_Base.png", "Product_Outfit_RetroCitizen_Female_Base.png" },
+                name = "Retro Citizen",
+                price = 870,
+                sexId = {
+                  female = 975,
+                  male = 974
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_RetroHunter_Male_Base.png", "Product_Outfit_RetroHunter_Female_Base.png" },
+                name = "Retro Hunter",
+                price = 870,
+                sexId = {
+                  female = 973,
+                  male = 972
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_RetroKnight_Male_Base.png", "Product_Outfit_RetroKnight_FemaleFix_Base.png" },
+                name = "Retro Knight",
+                price = 870,
+                sexId = {
+                  female = 971,
+                  male = 970
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_RetroMage_Male_Base.png", "Product_Outfit_RetroMage_Female_Base.png" },
+                name = "Retro Wizzard",
+                price = 870,
+                sexId = {
+                  female = 969,
+                  male = 968
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_RetroNobleman_Male_Base.png", "Product_Outfit_RetroNobleman_Female_Base.png" },
+                name = "Retro Noblewoman",
+                price = 870,
+                sexId = {
+                  female = 967,
+                  male = 966
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_RetroSummoner_Male_Base.png", "Product_Outfit_RetroSummoner_Female_Base.png" },
+                name = "Retro Summoner",
+                price = 870,
+                sexId = {
+                  female = 965,
+                  male = 964
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_RetroWarrior_Male_Base.png", "Product_Outfit_RetroWarrior_Female_Base.png" },
+                name = "Retro Warrior",
+                price = 870,
+                sexId = {
+                  female = 963,
+                  male = 962
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_Pharaoh_male_Full.png", "Product_Outfit_Pharaoh_female_Full.png" },
+                name = "Full Pharaoh Outfit",
+                price = 570,
+                sexId = {
+                  female = 956,
+                  male = 955
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_Pharaoh_male_Base.png", "Product_Outfit_Pharaoh_female_Base.png" },
+                name = "Pharaoh Outfit",
+                price = 390,
+                sexId = {
+                  female = 956,
+                  male = 955
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_Pharaoh_male_Addon1.png", "Product_Outfit_Pharaoh_female_Addon1.png" },
+                name = "Pharaoh Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 956,
+                  male = 955
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_Pharaoh_male_Addon2.png", "Product_Outfit_Pharaoh_female_Addon2.png" },
+                name = "Pharaoh Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 956,
+                  male = 955
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_AntlerDruid_male_Full.png", "Product_Outfit_AntlerDruid_female_Full.png" },
+                name = "Full Groove Keeper Outfit",
+                price = 870,
+                sexId = {
+                  female = 909,
+                  male = 908
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_AntlerDruid_male_Base.png", "Product_Outfit_AntlerDruid_female_Base.png" },
+                name = "Groove Keeper Outfit",
+                price = 690,
+                sexId = {
+                  female = 900,
+                  male = 899
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_AntlerDruid_male_Addon1.png", "Product_Outfit_AntlerDruid_female_Addon1.png" },
+                name = "Groove Keeper Addon 1",
+                price = 120,
+                sexId = {
+                  female = 900,
+                  male = 899
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_AntlerDruid_male_Addon2.png", "Product_Outfit_AntlerDruid_female_Addon2.png" },
+                name = "Groove Keeper Addon 2",
+                price = 120,
+                sexId = {
+                  female = 900,
+                  male = 899
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_LupinWarden_male_Full.png", "Product_Outfit_LupinWarden_female_Full.png" },
+                name = "Full Lupine Wardem Outfit",
+                price = 840,
+                sexId = {
+                  female = 900,
+                  male = 899
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_LupinWarden_male_Base.png", "Product_Outfit_LupinWarden_female_Base.png" },
+                name = "Lupine Wardem Outfit",
+                price = 660,
+                sexId = {
+                  female = 900,
+                  male = 899
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_LupinWarden_male_Addon1.png", "Product_Outfit_LupinWarden_female_Addon1.png" },
+                name = "Lupine Wardem Addon 1",
+                price = 120,
+                sexId = {
+                  female = 900,
+                  male = 899
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_LupinWarden_male_Addon2.png", "Product_Outfit_LupinWarden_female_Addon2.png" },
+                name = "Lupine WardemAddon 2",
+                price = 120,
+                sexId = {
+                  female = 900,
+                  male = 899
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_ArenaChampion_Male_Full.png", "Product_Outfit_ArenaChampion_Female_Full.png" },
+                name = "Full Arena Champion Outfit",
+                price = 870,
+                sexId = {
+                  female = 885,
+                  male = 884
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_ArenaChampion_Male_Base.png", "Product_Outfit_ArenaChampion_Female_Base.png" },
+                name = "Arena Champion Outfit",
+                price = 690,
+                sexId = {
+                  female = 885,
+                  male = 884
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_Beastmaster_Male_Addon2.png", "Product_Outfit_Beastmaster_Female_Addon2.png" },
+                name = "Arena Champion Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 885,
+                  male = 884
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_Beastmaster_Male_Addon1.png", "Product_Outfit_Beastmaster_Female_Addon1.png" },
+                name = "Arena Champion Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 885,
+                  male = 884
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_Professor_Male_Full.png", "Product_Outfit_Professor_Female_Full.png" },
+                name = "Full Philosopher Outfit",
+                price = 750,
+                sexId = {
+                  female = 874,
+                  male = 873
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_Professor_Male_Base.png", "Product_Outfit_Professor_Female_Base.png" },
+                name = "Philosopher Outfit",
+                price = 570,
+                sexId = {
+                  female = 874,
+                  male = 873
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_Professor_Male_Addon1.png", "Product_Outfit_Professor_Female_Addon1.png" },
+                name = "Philosopher Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 874,
+                  male = 873
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_Professor_Male_Addon2.png", "Product_Outfit_Professor_Female_Addon2.png" },
+                name = "Philosopher Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 874,
+                  male = 873
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_WinterWarden_Male_Full.png", "Product_Outfit_WinterWarden_Female_Full.png" },
+                name = "Full Winter Warden Outfit",
+                price = 870,
+                sexId = {
+                  female = 852,
+                  male = 853
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_WinterWarden_Male_Base.png", "Product_Outfit_WinterWarden_Female_Base.png" },
+                name = "Winter Warden Outfit",
+                price = 690,
+                sexId = {
+                  female = 852,
+                  male = 853
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_WinterWarden_Male_Addon1.png", "Product_Outfit_WinterWarden_Female_Addon1.png" },
+                name = "Winter Warden Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 852,
+                  male = 853
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_WinterWarden_Male_Addon2.png", "Product_Outfit_WinterWarden_Female_Addon2.png" },
+                name = "Winter Warden Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 852,
+                  male = 853
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_RoyalPumpkin_Male_Full.png", "Product_Outfit_RoyalPumpkin_Female_Full.png" },
+                name = "Full Royal Pumpkin Outfit",
+                price = 640,
+                sexId = {
+                  female = 759,
+                  male = 760
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_RoyalPumpkin_Male_Base.png", "Product_Outfit_RoyalPumpkin_Female_Base.png" },
+                name = "Royal Pumpkin Outfit",
+                price = 660,
+                sexId = {
+                  female = 759,
+                  male = 760
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_RoyalPumpkin_Male_Addon1.png", "Product_Outfit_RoyalPumpkin_Female_Addon1.png" },
+                name = "Royal Pumpkin Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 759,
+                  male = 760
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_RoyalPumpkin_Male_Addon2.png", "Product_Outfit_RoyalPumpkin_Female_Addon2.png" },
+                name = "Royal Pumpkin Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 759,
+                  male = 760
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_SeaDog_Male_Full.png", "Product_Outfit_SeaDog_Female_Full.png" },
+                name = "Full Sea Dog Outfit",
+                price = 600,
+                sexId = {
+                  female = 749,
+                  male = 750
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_SeaDog_Male_Base.png", "Product_Outfit_SeaDog_Female_Base.png" },
+                name = "Sea Dog Outfit",
+                price = 420,
+                sexId = {
+                  female = 749,
+                  male = 750
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_SeaDog_Male_Addon1.png", "Product_Outfit_SeaDog_Female_Addon1.png" },
+                name = "Sea Dog Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 749,
+                  male = 750
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_SeaDog_Male_Addon2.png", "Product_Outfit_SeaDog_Female_Addon2.png" },
+                name = "Sea Dog Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 749,
+                  male = 750
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_Champion_Male_Full.png", "Product_Outfit_Champion_Female_Full.png" },
+                name = "Full Champion Outfit",
+                price = 570,
+                sexId = {
+                  female = 632,
+                  male = 633
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_Champion_Male_Base.png", "Product_Outfit_Champion_Female_Base.png" },
+                name = "Champion Outfit",
+                price = 390,
+                sexId = {
+                  female = 632,
+                  male = 633
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_Champion_Male_Addon2.png", "Product_Outfit_Champion_Female_Addon2.png" },
+                name = "Champion Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 632,
+                  male = 633
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_Champion_Male_Addon1.png", "Product_Outfit_Champion_Female_Addon1.png" },
+                name = "Champion Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 632,
+                  male = 633
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_Conjurer_Male_Full.png", "Product_Outfit_Conjurer_Female_Full.png" },
+                name = "Full Conjurer Outfit",
+                price = 720,
+                sexId = {
+                  female = 635,
+                  male = 634
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_Conjurer_Male_Base.png", "Product_Outfit_Conjurer_Female_Base.png" },
+                name = "Conjurer Outfit",
+                price = 540,
+                sexId = {
+                  female = 635,
+                  male = 634
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_Conjurer_Male_Addon1.png", "Product_Outfit_Conjurer_Female_Addon1.png" },
+                name = "Conjurer Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 635,
+                  male = 634
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_Conjurer_Male_Addon2.png", "Product_Outfit_Conjurer_Female_Addon2.png" },
+                name = "Conjurer Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 635,
+                  male = 634
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_Beastmaster_Male_Full.png", "Product_Outfit_Beastmaster_Female_Full.png" },
+                name = "Full Beastmaster Outfit",
+                price = 870,
+                sexId = {
+                  female = 636,
+                  male = 637
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_Beastmaster_Male_Base.png", "Product_Outfit_Beastmaster_Female_Base.png" },
+                name = "Beastmaster Outfit",
+                price = 690,
+                sexId = {
+                  female = 636,
+                  male = 637
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_Beastmaster_Male_Addon1.png", "Product_Outfit_Beastmaster_Female_Addon1.png" },
+                name = "Beastmaster Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 636,
+                  male = 637
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_Beastmaster_Male_Addon2.png", "Product_Outfit_Beastmaster_Female_Addon2.png" },
+                name = "Beastmaster Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 637,
+                  male = 637
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_ChaosAcolyte_Male_Full.png", "Product_Outfit_ChaosAcolyte_Female_Full.png" },
+                name = "Full Chaos Acolyte Outfit",
+                price = 600,
+                sexId = {
+                  female = 664,
+                  male = 665
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_ChaosAcolyte_Male_Base.png", "Product_Outfit_ChaosAcolyte_Female_Base.png" },
+                name = "Chaos Acolyte Outfit",
+                price = 420,
+                sexId = {
+                  female = 664,
+                  male = 665
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_ChaosAcolyte_Male_Addon1.png", "Product_Outfit_ChaosAcolyte_Female_Addon1.png" },
+                name = "Chaos Acolyte Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 664,
+                  male = 665
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_ChaosAcolyte_Male_Addon2.png", "Product_Outfit_ChaosAcolyte_Female_Addon2.png" },
+                name = "Chaos Acolyte Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 664,
+                  male = 665
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_DeathHerald_Male_Full.png", "Product_Outfit_DeathHerald_Female_Full.png" },
+                name = "Full Death Herald Outfit",
+                price = 600,
+                sexId = {
+                  female = 666,
+                  male = 667
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_DeathHerald_Male_Base.png", "Product_Outfit_DeathHerald_Female_Base.png" },
+                name = "Death Herald Outfit",
+                price = 420,
+                sexId = {
+                  female = 666,
+                  male = 667
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_DeathHerald_Male_Addon1.png", "Product_Outfit_DeathHerald_Female_Addon1.png" },
+                name = "Death Herald Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 666,
+                  male = 667
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_DeathHerald_Male_Addon2.png", "Product_Outfit_DeathHerald_Female_Addon2.png" },
+                name = "Death Herald Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 666,
+                  male = 667
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_Ranger_Male_Full.png", "Product_Outfit_Ranger_Female_Full.png" },
+                name = "Full Ranger Outfit",
+                price = 750,
+                sexId = {
+                  female = 683,
+                  male = 684
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_Ranger_Male_Base.png", "Product_Outfit_Ranger_Female_Base.png" },
+                name = "Ranger Outfit",
+                price = 570,
+                sexId = {
+                  female = 683,
+                  male = 684
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_Ranger_Male_Addon1.png", "Product_Outfit_Ranger_Female_Addon1.png" },
+                name = "Ranger Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 683,
+                  male = 684
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_Ranger_Male_Addon2.png", "Product_Outfit_Ranger_Female_Addon2.png" },
+                name = "Ranger Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 683,
+                  male = 684
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_CeremonialGarb_Male_Full.png", "Product_Outfit_CeremonialGarb_Female_Full.png" },
+                name = "Full Ceremonial Garb Outfit",
+                price = 750,
+                sexId = {
+                  female = 694,
+                  male = 695
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_CeremonialGarb_Male_Base.png", "Product_Outfit_CeremonialGarb_Female_Base.png" },
+                name = "Ceremonial Garb Outfit",
+                price = 570,
+                sexId = {
+                  female = 694,
+                  male = 695
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_CeremonialGarb_Male_Addon1.png", "Product_Outfit_CeremonialGarb_Female_Addon1.png" },
+                name = "Ceremonial Garb Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 694,
+                  male = 695
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_CeremonialGarb_Male_Addon2.png", "Product_Outfit_CeremonialGarb_Female_Addon2.png" },
+                name = "Ceremonial Garb Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 694,
+                  male = 695
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_Puppeteer_Male_Full.png", "Product_Outfit_Puppeteer_Female_Full.png" },
+                name = "Full Puppeteer Outfit",
+                price = 870,
+                sexId = {
+                  female = 696,
+                  male = 697
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_Puppeteer_Male_Base.png", "Product_Outfit_Puppeteer_Female_Base.png" },
+                name = "Puppeteer Outfit",
+                price = 690,
+                sexId = {
+                  female = 696,
+                  male = 697
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_Puppeteer_Male_Addon1.png", "Product_Outfit_Puppeteer_Female_Addon1.png" },
+                name = "Puppeteer Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 696,
+                  male = 697
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_Puppeteer_Male_Addon2.png", "Product_Outfit_Puppeteer_Female_Addon2.png" },
+                name = "Puppeteer Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 696,
+                  male = 697
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_SpiritCaller_Male_Full.png", "Product_Outfit_SpiritCaller_Female_Full.png" },
+                name = "Full Spirit Caller Outfit",
+                price = 600,
+                sexId = {
+                  female = 698,
+                  male = 699
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_SpiritCaller_Male_Base.png", "Product_Outfit_SpiritCaller_Female_Base.png" },
+                name = "Spirit Caller Outfit",
+                price = 420,
+                sexId = {
+                  female = 698,
+                  male = 699
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_SpiritCaller_Male_Addon1.png", "Product_Outfit_SpiritCaller_Female_Addon1.png" },
+                name = "Spirit Caller Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 698,
+                  male = 699
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_SpiritCaller_Male_Addon2.png", "Product_Outfit_SpiritCaller_Female_Addon2.png" },
+                name = "Spirit Caller Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 698,
+                  male = 699
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_Evoker_Male_Full.png", "Product_Outfit_Evoker_Female_Full.png" },
+                name = "Full Evoker Outfit",
+                price = 840,
+                sexId = {
+                  female = 724,
+                  male = 725
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_Evoker_Male_Base.png", "Product_Outfit_Evoker_Female_Base.png" },
+                name = "Evoker Outfit",
+                price = 660,
+                sexId = {
+                  female = 724,
+                  male = 725
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_Evoker_Male_Addon1.png", "Product_Outfit_Evoker_Female_Addon1.png" },
+                name = "Evoker Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 724,
+                  male = 725
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_Evoker_Male_Addon2.png", "Product_Outfit_Evoker_Female_Addon2.png" },
+                name = "Evoker OutfitAddon 2",
+                price = 120,
+                sexId = {
+                  female = 724,
+                  male = 725
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 3,
+                icons = { "Product_Outfit_SeaWeaver_Male_Full.png", "Product_Outfit_SeaWeaver_Female_Full.png" },
+                name = "Full Seaweaver Outfit",
+                price = 570,
+                sexId = {
+                  female = 732,
+                  male = 733
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                icons = { "Product_Outfit_SeaWeaver_Male_Base.png", "Product_Outfit_SeaWeaver_Female_Base.png" },
+                name = "Seaweaver Outfit",
+                price = 390,
+                sexId = {
+                  female = 732,
+                  male = 733
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+              }, {
+                addon = 1,
+                icons = { "Product_Outfit_SeaWeaver_Male_Addon1.png", "Product_Outfit_SeaWeaver_Female_Addon1.png" },
+                name = "Seaweaver Outfit Addon 1",
+                price = 120,
+                sexId = {
+                  female = 732,
+                  male = 733
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              }, {
+                addon = 2,
+                icons = { "Product_Outfit_SeaWeaver_Male_Addon2.png", "Product_Outfit_SeaWeaver_Female_Addon2.png" },
+                name = "Seaweaver Outfit Addon 2",
+                price = 120,
+                sexId = {
+                  female = 732,
+                  male = 733
+                },
+                type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON,
+              } },
+   rookgaard = true,
+   state = GameStore.States.STATE_NONE,
+ }, {
+   description = "Buy exceptional equipment to upgrade your Tibia House",
+   icons = { "Category_HouseEquipment.png" },
+   name = "House Equipment",
+   offers = { {
+                count = 1,
+                icons = { "Product_HouseEquipment_alchemisticcabinet.png" },
+                name = "Alchemistic Cabinet",
+                price = 100,
+                id = 32020,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_alchemisticbookstand.png" },
+                name = "Alchemistic Bookstand",
+                price = 100,
+                id = 32031,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_alchemisticchair.png" },
+                name = "Alchemistic Chair",
+                price = 50,
+                id = 32018,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_lightofchange.png" },
+                name = "Light of Change",
+                price = 120,
+                id = 33174,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_kingtibianusbust.png" },
+                name = "King Tibianus Bust",
+                price = 50,
+                id = 32050,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_Carpet23.png" },
+                name = "Wheat Carpet",
+                price = 30,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_Carpet24.png" },
+                name = "Crested Carpet",
+                price = 25,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_Carpet25.png" },
+                name = "Decorated Carpet",
+                price = 35,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_EgyptianFurniture_Table.png" },
+                name = "Ornate Table",
+                price = 50,
+                id = 29397,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_EgyptianFurniture_Chair.png" },
+                name = "Ornate Chair",
+                price = 50,
+                id = 29395,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_EgyptianFurniture_Chest.png" },
+                name = "Ornate Chest",
+                price = 80,
+                id = 29403,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_EgyptianFurniture_Cupboard.png" },
+                name = "Ornate Cabinet",
+                price = 100,
+                id = 29399,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_Housepet_Snake.png" },
+                name = "Terrarium Snake",
+                price = 180,
+                id = 29408,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_NaturalFurniture_Chair.png" },
+                name = "Verdant Chair",
+                price = 50,
+                id = 29340,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_NaturalFurniture_Cabinet.png" },
+                name = "Verdant Cabinet",
+                price = 100,
+                id = 29342,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_NaturalFurniture_Chest.png" },
+                name = "Verdant Trunk",
+                price = 50,
+                id = 29346,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_NaturalFurniture_Table.png" },
+                name = "Verdant Table",
+                price = 80,
+                id = 29347,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_Carpet_18.png" },
+                name = "Verdant Carpet",
+                price = 30,
+                id = 29351,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_Carpet_19.png" },
+                name = "Shaggy Carpet",
+                price = 30,
+                id = 29353,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_Carpet_20.png" },
+                name = "Mystic Carpet",
+                price = 35,
+                id = 29355,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_Carpet_22.png" },
+                name = "Wooden Planks",
+                price = 25,
+                id = 29359,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_HrodmirianWeaponRack.png" },
+                name = "Hrodmiran Weapons Rack",
+                price = 90,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_BabyGiantSpider.png" },
+                name = "Terrarium Spider",
+                price = 180,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                icons = { "Product_HouseEquipment_ShinyDailyRewardShrine.png" },
+                name = "Shiny Daily Reward Shrine",
+                price = 150,
+                id = 29024,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Vengothic Chair to decorate your home.",
+                icons = { "Product_HouseEquipment_VengothicFurniture_Chair.png" },
+                name = "Vengothic Chair",
+                price = 50,
+                id = 27900,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Vengothic Chest to decorate your home.",
+                icons = { "Product_HouseEquipment_VengothicFurniture_Chest.png" },
+                name = "Vengothic Chest",
+                price = 80,
+                id = 27908,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Vengothic Cabinet to decorate your home.",
+                icons = { "Product_HouseEquipment_VengothicFurniture_Cupboard.png" },
+                name = "Vengothic Cabinet",
+                price = 100,
+                id = 27904,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Vengothic Table to decorate your home.",
+                icons = { "Product_HouseEquipment_VengothicFurniture_Table.png" },
+                name = "Vengothic Table",
+                price = 50,
+                id = 27902,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Vengothic Lamp to decorate your home.",
+                icons = { "Product_HouseEquipment_VengothicLamp.png" },
+                name = "Vengothic Lamp",
+                price = 180,
+                id = 27909,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Chamaleon to decorate your home.",
+                icons = { "Product_HouseEquipment_Chameleon.png" },
+                name = "Chamaleon",
+                price = 250,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Blooming Cactus to decorate your home.",
+                icons = { "Product_HouseEquipment_BloomingCactus.png" },
+                name = "Blooming Cactus",
+                price = 50,
+                id = 27892,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Bitter-Smack Leaf to decorate your home.",
+                icons = { "Product_HouseEquipment_BitterSmackLeaf.png" },
+                name = "Bitter-Smack Leaf",
+                price = 50,
+                id = 27893,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Pink Roses to decorate your home.",
+                icons = { "Product_HouseEquipment_PinkRoses.png" },
+                name = "Pink Roses",
+                price = 50,
+                id = 27894,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Red Roses to decorate your home.",
+                icons = { "Product_HouseEquipment_RedRoses.png" },
+                name = "Red Roses",
+                price = 50,
+                id = 27895,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Yellow Roses to decorate your home.",
+                icons = { "Product_HouseEquipment_YellowRoses.png" },
+                name = "Yellow Roses",
+                price = 50,
+                id = 27896,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Parrot to decorate your home.",
+                icons = { "Product_HouseEquipment_Housepet_Parrot.png" },
+                name = "Parrot",
+                price = 180,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Flowery Carpet to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet_10.png" },
+                name = "Flowery Carpet",
+                price = 35,
+                id = 27092,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Colourful Carpet to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet_11.png" },
+                name = "Colourful Carpet",
+                price = 35,
+                id = 27093,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Striped Carpet to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet_12.png" },
+                name = "Striped Carpet",
+                price = 35,
+                id = 27094,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Patterned Carpet to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet_15.png" },
+                name = "Patterned Carpet",
+                price = 30,
+                id = 27097,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Fur Carpet to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet_13.png" },
+                name = "Fur Carpet",
+                price = 30,
+                id = 27095,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Diamond Carpet to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet_14.png" },
+                name = "Diamond Carpet",
+                price = 30,
+                id = 27096,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an Night Sky Carpet Carpet to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet_16.png" },
+                name = "Night Sky Carpet",
+                price = 30,
+                id = 27098,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Star Carpet to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet_17.png" },
+                name = "Star Carpet",
+                price = 30,
+                id = 27099,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Gilded Imbuing Shrine to decorate your home.",
+                icons = { "Product_HouseEquipment_GildedImbuingShrine.png" },
+                name = "Gilded Imbuing Shrine",
+                price = 200,
+                id = 27851,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Imbuing Shrine to decorate your home.",
+                icons = { "Product_HouseEquipment_ImbuingShrine.png" },
+                name = "Imbuing Shrine",
+                price = 150,
+                id = 27729,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Dog House to decorate your home.",
+                icons = { "Product_HouseEquipment_Housepet_DogHouse.png" },
+                name = "Dog House",
+                price = 150,
+                id = 26365,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Golden Dragon Tapestry to decorate your home.",
+                icons = { "Product_HouseEquipment_Tapestry_04.png" },
+                name = "Golden Dragon Tapestry",
+                price = 70,
+                id = 26379,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Sword Tapestry to decorate your home.",
+                icons = { "Product_HouseEquipment_Tapestry_05.png" },
+                name = "Sword Tapestry",
+                price = 60,
+                id = 26380,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Brocade Tapestry to decorate your home.",
+                icons = { "Product_HouseEquipment_Tapestry_06.png" },
+                name = "Brocade Tapestry",
+                price = 50,
+                id = 26381,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Rustic Cabinet to decorate your home.",
+                icons = { "Product_HouseEquipment_RusticFurniture_Cabinet.png" },
+                name = "Rustic Cabinet",
+                price = 100,
+                id = 26357,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Rustic Chair to decorate your home.",
+                icons = { "Product_HouseEquipment_RusticFurniture_Chair.png" },
+                name = "Rustic Chair",
+                price = 50,
+                id = 26352,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Rustic Trunk to decorate your home.",
+                icons = { "Product_HouseEquipment_RusticFurniture_Chest.png" },
+                name = "Rustic Trunk",
+                price = 80,
+                id = 26362,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Rustic Table to decorate your home.",
+                icons = { "Product_HouseEquipment_RusticFurniture_Table.png" },
+                name = "Rustic Table",
+                price = 50,
+                id = 26355,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Crimson Carpet to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet_04.png" },
+                name = "Crimson Carpet",
+                price = 35,
+                id = 26371,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Azure Carpet to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet_05.png" },
+                name = "Azure Carpet",
+                price = 35,
+                id = 26372,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Emerald Carpet to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet_06.png" },
+                name = "Emerald Carpet",
+                price = 30,
+                id = 26373,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Light Parquet to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet_07.png" },
+                name = "Light Parquet",
+                price = 30,
+                id = 26374,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Dark Parquet to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet_08.png" },
+                name = "Dark Parquet",
+                price = 30,
+                id = 26375,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Marble Floor to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet_09.png" },
+                name = "Marble Floor",
+                price = 30,
+                id = 23259,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Baby Dragon to decorate your home.",
+                icons = { "Product_HouseEquipment_Housepet_BabyDragon.png" },
+                name = "Baby Dragon",
+                price = 250,
+                id = 26099,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Cat in a Basket to decorate your home.",
+                icons = { "Product_HouseEquipment_Housepet_Cat.png" },
+                name = "Cat in a Basket",
+                price = 150,
+                id = 26108,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Hamster in a Wheel to decorate your home.",
+                icons = { "Product_HouseEquipment_Housepet_Hamster.png" },
+                name = "Hamster in a Wheel",
+                price = 180,
+                id = 26101,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Magnificent Cabinet to decorate your home.",
+                icons = { "Product_HouseEquipment_BaroqueFurniture_Cabinet.png" },
+                name = "Magnificent Cabinet",
+                price = 100,
+                id = 26076,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Magnificent chair to decorate your home.",
+                icons = { "Product_HouseEquipment_BaroqueFurniture_Chair.png" },
+                name = "Magnificent Chair",
+                price = 60,
+                id = 26062,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Magnificent Trunk to decorate your home.",
+                icons = { "Product_HouseEquipment_BaroqueFurniture_Chest.png" },
+                name = "Magnificent Trunk",
+                price = 70,
+                id = 26086,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Magnificent Table to decorate your home.",
+                icons = { "Product_HouseEquipment_BaroqueFurniture_Table.png" },
+                name = "Magnificent Table",
+                price = 60,
+                id = 26074,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Ferocious Cabinet to decorate your home.",
+                icons = { "Product_HouseEquipment_TortureChamberFurniture_Cabinet.png" },
+                name = "Ferocious Cabinet",
+                price = 110,
+                id = 26078,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Ferocious Chair to decorate your home.",
+                icons = { "Product_HouseEquipment_TortureChamberFurniture_Chair.png" },
+                name = "Ferocious Chair",
+                price = 50,
+                id = 26066,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Ferocious Trunk to decorate your home.",
+                icons = { "Product_HouseEquipment_TortureChamberFurniture_Chest.png" },
+                name = "Ferocious Trunk",
+                price = 80,
+                id = 26082,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Ferocious Table to decorate your home.",
+                icons = { "Product_HouseEquipment_TortureChamberFurniture_Table.png" },
+                name = "Ferocious Table",
+                price = 50,
+                id = 26070,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Yalaharian Carpet to decorateyour home.",
+                icons = { "Product_HouseEquipment_Carpet1.png" },
+                name = "Yalaharian Carpet",
+                price = 35,
+                id = 26109,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible White Fur Carpet to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet2.png" },
+                name = "White Fur Carpet",
+                price = 30,
+                id = 26110,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 26111,
+                description = "Buy an incredible Bamboo Mat to decorate your home.",
+                icons = { "Product_HouseEquipment_Carpet3.png" },
+                name = "Bamboo Mat",
+                price = 25,
+                id = 26111,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Royal Mailbox to decorate your home.",
+                icons = { "Product_HouseEquipment_Mailbox_Golden.png" },
+                name = "Royal Mailbox",
+                price = 150,
+                id = 26056,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Ornate Mailbox to decorate your home.",
+                icons = { "Product_HouseEquipment_Mailbox_Standard.png" },
+                name = "Ornate Mailbox",
+                price = 200,
+                id = 26058,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              }, {
+                count = 1,
+                description = "Buy an incredible Menacing Tapestry to decorate your home.",
+                icons = { "Product_HouseEquipment_Tapestry_02.png" },
+                name = "Menacing Tapestry",
+                price = 70,
+                id = 26105,
+                type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+              } },
+   rookgaard = true,
+   state = GameStore.States.STATE_NONE,
+ }, {
+   description = "Buy your character a boost to speed up your character development.",
+   icons = { "Category_Boosts.png" },
+   name = "XP Boost",
+   offers = { {
+                icons = { "xpboosticon.png" },
+                name = "XP Boost 50%",
+                price = 30,
+                id = 65541,
+                type = GameStore.OfferTypes.OFFER_TYPE_EXPBOOST,
+              } },
+   rookgaard = true,
+   state = GameStore.States.STATE_NONE,
+ }, {
+   description = "Buy yourcharacter one or more of the helpful items offered here.",
+   icons = { "Category_Convenience.png" },
+   name = "Useful Things",
+   offers = { {
+                count = 1,
+                icons = { "Product_UsefulThings_PreyBonusReroll.png" },
+                name = "Prey Bonus Reroll",
+                price = 5,
+                id = 65540,
+                type = GameStore.OfferTypes.OFFER_TYPE_PREYBONUS,
+              }, {
+                count = 5,
+                icons = { "Product_UsefulThings_PreyBonusReroll.png" },
+                name = "5x Prey Bonus Reroll",
+                price = 25,
+                id = 65539,
+                type = GameStore.OfferTypes.OFFER_TYPE_PREYBONUS,
+              }, {
+                icons = { "Product_UsefulThings_PreyBonusReroll.png" },
+                name = "Permanent Prey Slot",
+                price = 450,
+                id = 65538,
+                type = GameStore.OfferTypes.OFFER_TYPE_PREYSLOT,
+              }, {
+                icons = { "Product_Transportation_TempleTeleport.png" },
+                name = "Temple Teleport",
+                price = 25,
+                id = 65537,
+                type = GameStore.OfferTypes.OFFER_TYPE_TEMPLE,
+              },
+              {
+                name = "Gold Pouch",
+                id = 26377,
+                count = 1,
+                type = GameStore.OfferTypes.OFFER_TYPE_ITEM,
+                price = 900,
+                icons = { "Product_MagicCoinPurse.png" },
+                description = "With Gold Pounch you can carry the amount of gold without having to keep many knapsacks in the backpack, this product allows you to be charged as much gold as your ability allows." }
+   },
+   rookgaard = true,
+   state = GameStore.States.STATE_NONE,
+} }
 
-	{
-		name = "Runes",
-		state = GameStore.States.STATE_NONE,
-        description = "Buy magically filled runes to unleash their energy when in need of it.",
-		rookgaard = true,
-		icons = {"Category_Runes.png"},
-		offers = {
-			{name = "Animate Dead Rune", description = "Here you can purchase a stack of '250 Animate Dead Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 75, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2316, count = 250, icons = {"Product_Rune_AnimateDeadRune.png"}},
-			{name = "Avalanche Rune", description = "Here you can purchase a stack of '250 Avalanche Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 9, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2274, count = 250, icons = {"Product_Rune_AvalancheRune.png"}},
-			{name = "Chameleon Rune", description = "Here you can purchase a stack of '250 Chameleon Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 42, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2291, count = 250, icons = {"Product_Rune_ChameleonRune.png"}},
-			{name = "Convince Creature Rune", description = "Here you can purchase a stack of '250 Convince Creature Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 16, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2290, count = 250, icons = {"Product_Rune_ConvinceRune.png"}},
-			{name = "Cure Poison Rune", description = "Here you can purchase a stack of '250 Cure Poison Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 13, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2266, count = 250, icons = {"Product_Rune_CurePoisonRune.png"}},
-			{name = "Disintegrate Rune", description = "Here you can purchase a stack of '250 Disintegrate Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 5, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2310, count = 250, icons = {"Product_Rune_DisintegrateRune.png"}},
-			{name = "Energy Bomb Rune", description = "Here you can purchase a stack of '250 Energy Bomb Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 32, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2262, count = 250, icons = {"Product_Rune_EnergyBombRune.png"}},
-			{name = "Energy Field Rune", description = "Here you can purchase a stack of '250 Energy Field Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 8, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2277, count = 250, icons = {"Product_Rune_EnergyFieldRune.png"}},
-			{name = "Energy Wall Rune", description = "Here you can purchase a stack of '250 Energy Wall Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 17, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2279, count = 250, icons = {"Product_Rune_EnergyWallRune.png"}},
-			{name = "Explosion Rune", description = "Here you can purchase a stack of '250 Explosion Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 6, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2313, count = 250, icons = {"Product_Rune_ExplosionRune.png"}},
-			{name = "Fireball Rune", description = "Here you can purchase a stack of '250 Fireball Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 6, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2302, count = 250, icons = {"Product_Rune_FireballRune.png"}},
-			{name = "Fire Bomb Rune", description = "Here you can purchase a stack of '250 Fire Bomb Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 23, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2305, count = 250, icons = {"Product_Rune_FireBombRune.png"}},
-			{name = "Fire Field Rune", description = "Here you can purchase a stack of '250 Fire Field Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 6, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2301, count = 250, icons = {"Product_Rune_FireFieldRune.png"}},
-			{name = "Fire Wall Rune", description = "Here you can purchase a stack of '250 Fire Wall Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 12, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2303, count = 250, icons = {"Product_Rune_FireWallRune.png"}},
-			{name = "Great Fireball Rune", description = "Here you can purchase a stack of 'Great Fireball Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 9, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2304, count = 250, icons = {"Product_Rune_GreatFireBallRune.png"}},
-			{name = "Icicle Rune", description = "Here you can purchase a stack of '250 Icicle Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 6, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2271, count = 250, icons = {"Product_Rune_IcicleRune.png"}},
-			{name = "Intense Healing Rune", description = "Here you can purchase a stack of '250 Intense Healing Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 19, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2265, count = 250, icons = {"Product_Rune_IntenseHealingRune.png"}},
-			{name = "Magic Wall Rune", description = "Here you can purchase a stack of '250 Magic Wall Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 23, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2293, count = 250, icons = {"Product_Rune_MagicWallRune.png"}},
-			{name = "Paralyse Rune", description = "Here you can purchase a stack of '250 Paralyse Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 140, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2278, count = 250, icons = {"Product_Rune_ParalyseRune.png"}},
-			{name = "Poison Bomb Rune", description = "Here you can purchase a stack of '250 Poison Bomb Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 17, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2286, count = 250, icons = {"Product_Rune_PoisonBombRune.png"}},
-			{name = "Poison Wall Rune", description = "Here you can purchase a stack of '250 Poison Wall Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 10, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2289, count = 250, icons = {"Product_Rune_PoisonWallRune.png"}},
-			{name = "Soulfire Rune", description = "Here you can purchase a stack of '250 Soulfire Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 9, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2308, count = 250, icons = {"Product_Rune_SoulfireRune.png"}},
-			{name = "Stone Shower Rune", description = "Here you can purchase a stack of '250 Stone Shower Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 7, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2288, count = 250, icons = {"Product_Rune_StoneShowerRune.png"}},
-			{name = "Sudden Death Rune", description = "Here you can purchase a stack of '250 Sudden Death Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 22, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2268, count = 250, icons = {"Product_Rune_SuddenDeathRune.png"}},
-			{name = "Thunderstorm Rune", description = "Here you can purchase a stack of '250 Thunderstorm Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 7, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2315, count = 250, icons = {"Product_Rune_ThunderstormRune.png"}},
-			{name = "Ultimate Healing Rune", description = "Here you can purchase a stack of '250 Ultimate Healing Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 35, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2273, count = 250, icons = {"Product_Rune_UltimateHealingRune.png"}},
-			{name = "Wild Growth Rune", description = "Here you can purchase a stack of '250 Wild Growth Runes'. Use them to unleash their magical energy when in need of it.Note, characters with a protection zone block or a battle sign cannot purchase runes. Also, characters cannot buy runes that exceed their capacity. Finally, runes bought in the Store can only be used by the character that makes the purchase. For this reason, the purchased runes need to fit the character's level and magic level.", price = 32, type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE, thingId = 2269, count = 250, icons = {"Product_Rune_WildGrowthRune.png"}},
-		}
-	},
-	
-	{
-		name = "Mounts",
-		state = GameStore.States.STATE_NONE,
-		icons = {"Category_Mounts.png"},
-		description = "Buy your character one or more of the fabolous Mounts offered here.",
-		rookgaard = true,
-		offers = {	
-					{name = "Cranium Spider", description = "Here you can purchase the Mount 'Cranium Spider' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 116, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 690, icons = {"Product_Mount_SkullSpider_v1.png"}},
-					{name = "Cave Tarantula", description = "Here you can purchase the Mount 'Cave Tarantula' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 117, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 690, icons = {"Product_Mount_SkullSpider_v2.png"}},
-					{name = "Gloom Widow", description = "Here you can purchase the Mount 'Snow Pelt' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 118, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 690, icons = {"Product_Mount_SkullSpider_v3.png"}},	
-					{name = "Blazing Unicorn", description = "Here you can purchase the Mount 'Gloom Widow' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 113, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_UnicornFire.png"}},
-					{name = "Artic Unicorn", description = "Here you can purchase the Mount 'Artic Unicorn' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 114, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_UnicornRainbow.png"}},
-					{name = "Prismatic Unicorn", description = "Here you can purchase the Mount 'Prismatic Unicorn' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 115, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_UnicornIce.png"}},
-					{name = "Armoured War Horse", description = "Here you can purchase the Mount 'Armoured War Horse' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 23, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_ArmouredWarHorse.png"}},
-					{name = "Shadow Draptor", description = "Here you can purchase the Mount 'Shadow Draptor' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 24, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_shadowdraptor.png"}},
-					{name = "Steelbeak", description = "Here you can purchase the Mount 'Steelbeak' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 34, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_steelbeak.png"}},
-					{name = "Crimson Ray", description = "Here you can purchase the Mount 'Crimson Ray' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 33, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_crimsonray.png"}},
-					{name = "Jungle Saurian", description = "Here you can purchase the Mount 'Jungle Saurian' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 110, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_Saurian_v1.png"}},
-					{name = "Ember Saurian", description = "Here you can purchase the Mount 'Ember Saurian' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 111, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_Saurian_v2.png"}},
-					{name = "Lagoon Saurian", description = "Here you can purchase the Mount 'Lagoon Saurian' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 112, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_Saurian_v3.png"}},
-					{name = "Gold Sphinx", description = "Here you can purchase the Mount 'Gold Sphinx' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 107, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_Sphinx_v1.png"}},
-					{name = "Emerald Sphinx", description = "Here you can purchase the Mount 'Emerald Sphinx' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 108, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_Sphinx_v2.png"}},
-					{name = "Shadow Sphinx", description = "Here you can purchase the Mount 'Shadow Sphinx' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 109, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_Sphinx_v3.png"}},
-					{name = "Jackalope", description = "Here you can purchase the Mount 'Jackalope' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 103, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_AntleredRabbit_v1.png"}},
-					{name = "Dreadhare", description = "Here you can purchase the Mount 'Dreadhare' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 104, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_AntleredRabbit_v2.png"}},
-					{name = "Wolpertinger", description = "Here you can purchase the Mount 'Wolpertinger' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 105, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_AntleredRabbit_v3.png"}},
-					{name = "Ivory Fang", description = "Here you can purchase the Mount 'Ivory Fang' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 100, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_ivoryfang.png"}},
-					{name = "Shadow Claw", description = "Here you can purchase the Mount 'Shadow Claw' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 101, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_ShadowClaw.png"}},
-					{name = "Snow Pelt", description = "Here you can purchase the Mount 'Snow Pelt' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", description = "Here you can purchase the Mount 'Snow Pelt' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 102, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_SnowPelt.png"}},
-					{name = "Swamp Snapper", description = "Here you can purchase the Mount 'Swamp Snapper' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 95, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 690, icons = {"Product_Mount_SwampSnapper.png"}},	
-					{name = "Mould Shell", description = "Here you can purchase the Mount 'Mould Shell' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 96, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 690, icons = {"Product_Mount_MouldShell.png"}},		
-					{name = "Reed Lurker", description = "Here you can purchase the Mount 'Reed Lurker' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 97, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 690, icons = {"Product_Mount_ReedLurker.png"}},
-					{name = "Bloodcurl", description = "Here you can purchase the Mount 'Bloodcurl' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 92, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 720, icons = {"Product_Mount_Bloodcurl.png"}},
-					{name = "Leafscuttler", description = "Here you can purchase the Mount 'Leafscuttler' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 93, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_Leafscuttler.png"}},
-					{name = "Mouldpincer", description = "Here you can purchase the Mount 'Mouldpincer' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 91, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_Mouldpincer.png"}},
-					{name = "Nightdweller", description = "Here you can purchase the Mount 'Nightdweller' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 88, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_Nightdweller.png"}},
-					{name = "Frostflare", description = "Here you can purchase the Mount 'Frostflare' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 89, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_Frostflare.png"}},
-					{name = "Cinderhoof", description = "Here you can purchase the Mount 'Cinderhoof' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 90, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_Cinderhoof.png"}},
-					{name = "Slagsnare", description = "Here you can purchase the Mount 'Slagsnare' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 84, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 780, icons = {"Product_Mount_Slagsnare.png"}},
-					{name = "Nightstinger", description = "Here you can purchase the Mount 'Nightstinger' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 85, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 780, icons = {"Product_Mount_Nightstinger.png"}},
-					{name = "Razorcreep", description = "Here you can purchase the Mount 'Razorcreep' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 86, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 780, icons = {"Product_Mount_Razorcreep.png"}},
-					{name = "Gorongra", description = "Here you can purchase the Mount 'Gorongra' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 81, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 720, icons = {"Product_Mount_Gorongra.png"}},
-					{name = "Noctungra", description = "Here you can purchase the Mount 'Noctungra' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 82, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 720, icons = {"Product_Mount_Noctungra.png"}},
-					{name = "Silverneck", description = "Here you can purchase the Mount 'Silverneck' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 83, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 720, icons = {"Product_Mount_Silverneck.png"}},
-					{name = "Sea Devil", description = "Here you can purchase the Mount 'Sea Devil' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 78, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 570, icons = {"Product_Mount_SeaDevil.png"}},	
-					{name = "Coralripper", description = "Here you can purchase the Mount 'Coralripper' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 79, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 570, icons = {"Product_Mount_Coralripper.png"}},
-					{name = "Plumfish", description = "Here you can purchase the Mount 'Plumfish' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 80, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 570, icons = {"Product_Mount_Plumfish.png"}},
-					{name = "Flitterkatzen", description = "Here you can purchase the Mount 'Flitterkatzen' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 75, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_Flitterkatzen.png"}},
-					{name = "Venompaw", description = "Here you can purchase the Mount 'Venompaw' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 76, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_Venompaw.png"}},
-					{name = "Batcat", description = "Here you can purchase the Mount 'Batcat' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 77, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 870, icons = {"Product_Mount_BatCat.png"}},
-					{name = "Ringtail Waccoon", description = "Here you can purchase the Mount 'Ringtail Waccoon' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 68, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_RingtailWaccoon.png"}},
-					{name = "Night Waccoon", description = "Here you can purchase the Mount 'Night Waccoon' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 69, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_NightWaccoon.png"}},
-					{name = "Emerald Waccoon", description = "Here you can purchase the Mount 'Emerald Waccoon' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 70, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_EmeraldWaccoon.png"}},
-					{name = "Flying Divan", description = "Here you can purchase the Mount 'Flying Divan' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 65, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 900, icons = {"Product_Mount_FlyingDivan.png"}},
-					{name = "Magic Carpet", description = "Here you can purchase the Mount 'Magic Carpet' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 66, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 900, icons = {"Product_Mount_MagicCarpet.png"}},
-					{name = "Floating Kashmir", description = "Here you can purchase the Mount 'Floating Kashmir' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 67, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 900, icons = {"Product_Mount_FloatingKashmir.png"}},
-					{name = "Shadow Hart", description = "Here you can purchase the Mount 'Shadow Hart' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 72, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 660, icons = {"Product_Mount_ShadowHart.png"}},
-					{name = "Black Stag", description = "Here you can purchase the Mount 'Black Stag' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 73, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 660, icons = {"Product_Mount_BlackStag.png"}},
-					{name = "Emperor Deer", description = "Here you can purchase the Mount 'Emperor Deer' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 74, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 660, icons = {"Product_Mount_EmperorDeer.png"}},
-					{name = "Tundra Rambler", description = "Here you can purchase the Mount 'Tundra Rambler' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 62, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_TundraRambler.png"}},
-					{name = "Highland Yak", description = "Here you can purchase the Mount 'Highland Yak' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 63, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_HighlandYak.png"}},
-					{name = "Glacier Vagabond", description = "Here you can purchase the Mount 'Glacier Vagabond' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 64, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 750, icons = {"Product_Mount_GlacierVagabond.png"}},
-		            {name = "Golden Dragonfly", description = "Here you can purchase the Mount 'Golden Dragonfly' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 59, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 600, icons = {"Product_Mount_GoldenDragonfly.png"}},
-		        	{name = "Steel Bee", description = "Here you can purchase the Mount 'Steel Bee' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 60, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 600, icons = {"Product_Mount_SteelBee.png"}},
-		        	{name = "Copper Fly", description = "Here you can purchase the Mount 'Copper Fly' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 61, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 600, icons = {"Product_Mount_CopperFly.png"}},
-		            {name = "Doombringer", description = "Here you can purchase the Mount 'Doombringer' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 53, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 780, icons = {"Product_Mount_Doombringer.png"}},	
-			        {name = "Woodland Prince", description = "Here you can purchase the Mount 'Woodland Prince' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 54, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 780, icons = {"Product_Mount_WoodlandPrince.png"}},
-					{name = "Hailtorm Fury", description = "Here you can purchase the Mount 'Hailtorm Fury' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 55, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 780, icons = {"Product_Mount_HailstormFury.png"}},
-		            {name = "Siegebreaker", description = "Here you can purchase the Mount 'Siegebreaker' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 56, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 690, icons = {"Product_Mount_Siegebreaker.png"}},
-		         	{name = "Poisonbane", description = "Here you can purchase the Mount 'Poisonbane' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 57, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 690, icons = {"Product_Mount_Poisonbane.png"}},
-			        {name = "Blackpelt", description = "Here you can purchase the Mount 'Blackpelt' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 58, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 690, icons = {"Product_Mount_Blackpelt.png"}},
-					{name = "Nethersteed", description = "Here you can purchase the Mount 'Nethersteed' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 50, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 900, icons = {"Product_Mount_Nethersteed.png"}},
-					{name = "Tempest", description = "Here you can purchase the Mount 'Tempest' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 51, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 900, icons = {"Product_Mount_Tempest.png"}},
-					{name = "Flamesteed", description = "Here you can purchase the Mount 'Flamesteed' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 47, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 900, icons = {"Product_Mount_Flamesteed.png"}},
-					{name = "Tombstinger", description = "Here you can purchase the Mount 'Tombstinger' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 36, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 600, icons = {"Product_Mount_Tombstinger.png"}},
-					{name = "Death Crawler", description = "Here you can purchase the Mount 'Death Crawler' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 46, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 600, icons = {"Product_Mount_DeathCrawler.png"}},
-					{name = "Jade Pincer", description = "Here you can purchase the Mount 'Jade Pincer' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 49, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 600, icons = {"Product_Mount_JadePincer.png"}},
-	            	{name = "Desert King", description = "Here you can purchase the Mount 'Desert King' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 41, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 450, icons = {"Product_Mount_DesertKing.png"}},
-                    {name = "Jade Lion", description = "Here you can purchase the Mount 'Jade Lion' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 48, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 450, icons = {"Product_Mount_JadeLion.png"}},
-                    {name = "Winter King",description = "Here you can purchase the Mount 'Winter king' for your character. Riding on a mount is not only cool, but also gives your character a speed boost. Note: The Mount will only be received by the character who purchased it in the Store.", thingId = 52, type = GameStore.OfferTypes.OFFER_TYPE_MOUNT, price = 450, icons = {"Product_Mount_WinterKing.png"}},
 
-}
-	},
-
-	{
-		name = "Outfits",
-		state = GameStore.States.STATE_NONE,
-	    description = "Buy your character one more of the classy outfits offered here.",
-		icons = {"Category_Outfits.png"},
-		rookgaard = true,
-		offers = {
-				--Sun Priest
-				{name = "Full Sun Priest Outfit", thingId = {male=1024,female=1023}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 750, icons = {"Product_Outfit_SunPriest_Male_Full.png", "Product_Outfit_SunPriest_Female_Full.png"}},
-				{name = "Sun Priest Outfit", thingId = {male=1024,female=1023}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 570, icons = {"Product_Outfit_SunPriest_Male_Base.png", "Product_Outfit_SunPriest_Female_Base.png"}},
-				{name = "Sun Priest Addon 1", thingId = {male=1024,female=1023}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_SunPriest_Male_Addon1.png", "Product_Outfit_SunPriest_Female_Addon1.png"}},
-				{name = "Sun Priest Addon 2", thingId = {male=1024,female=1023}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_SunPriest_Male_Addon2.png", "Product_Outfit_SunPriest_Female_Addon1.png"}},
-				--Herbalist
-				{name = "Full Herbalist Outfit", thingId = {male=1021,female=1020}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 750, icons = {"Product_Outfit_Herbalist_Male_Full.png", "Product_Outfit_Herbalist_Female_Full.png"}},
-				{name = "Herbalist Outfit", thingId = {male=1021,female=1020}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 570, icons = {"Product_Outfit_Herbalist_Male_Base.png", "Product_Outfit_Herbalist_Female_Base.png"}},
-				{name = "Herbalist Addon 1", thingId = {male=1021,female=1020}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Herbalist_Male_Addon1.png", "Product_Outfit_Herbalist_Female_Addon1.png"}},
-				{name = "Herbalist Addon 2", thingId = {male=1021,female=1020}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Herbalist_Male_Addon2.png", "Product_Outfit_Herbalist_Female_Addon1.png"}},
-				--Entrepreneur
-				{name = "Full Entrepreneur Outfit", thingId = {male=472,female=471}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 750, icons = {"Product_Outfit_Entrepreneur_Male_Full.png", "Product_Outfit_Entrepreneur_Female_Full.png"}},
-				{name = "Entrepreneur Outfit", thingId = {male=472,female=471}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 570, icons = {"Product_Outfit_Entrepreneur_Male_Base.png", "Product_Outfit_Entrepreneur_Female_Base.png"}},
-				{name = "Entrepreneur Addon 1", thingId = {male=472,female=471}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Entrepreneur_Male_Addon1.png", "Product_Outfit_Entrepreneur_Female_Addon1.png"}},
-				{name = "Entrepreneur Addon 2", thingId = {male=472,female=471}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Entrepreneur_Male_Addon2.png", "Product_Outfit_Entrepreneur_Female_Addon1.png"}},
-				--Trophy Hunter
-				{name = "Full Trophy Hunter Outfit", thingId = {male=899,female=900}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 870, icons = {"Product_Outfit_TrophyHunter_Male_Full.png", "Product_Outfit_TrophyHunter_Female_Full.png"}},
-				{name = "Trophy Hunter Outfit", thingId = {male=899,female=900}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 690, icons = {"Product_Outfit_TrophyHunter_Male_Base.png", "Product_Outfit_TrophyHunter_Female_Base.png"}},
-				{name = "Trophy Hunter Addon 1", thingId = {male=899,female=900}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_TrophyHunter_Male_Addon1.png", "Product_Outfit_TrophyHunter_Female_Addon1.png"}},
-				{name = "Trophy Hunter Addon 2", thingId = {male=899,female=900}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_TrophyHunter_Male_Addon2.png", "Product_Outfit_TrophyHunter_Female_Addon1.png"}},		
-				--Retro Outfits
-				{name = "Retro Citizen", thingId = {male=974,female=975}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 870, icons = {"Product_Outfit_RetroCitizen_Male_Base.png", "Product_Outfit_RetroCitizen_Female_Base.png"}},
-				{name = "Retro Hunter", thingId = {male=972,female=973}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 870, icons = {"Product_Outfit_RetroHunter_Male_Base.png", "Product_Outfit_RetroHunter_Female_Base.png"}},
-				{name = "Retro Knight", thingId = {male=970,female=971}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 870, icons = {"Product_Outfit_RetroKnight_Male_Base.png", "Product_Outfit_RetroKnight_FemaleFix_Base.png"}},
-				{name = "Retro Wizzard", thingId = {male=968,female=969}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 870, icons = {"Product_Outfit_RetroMage_Male_Base.png", "Product_Outfit_RetroMage_Female_Base.png"}},
-				{name = "Retro Noblewoman", thingId = {male=966,female=967}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 870, icons = {"Product_Outfit_RetroNobleman_Male_Base.png", "Product_Outfit_RetroNobleman_Female_Base.png"}},
-				{name = "Retro Summoner", thingId = {male=964,female=965}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 870, icons = {"Product_Outfit_RetroSummoner_Male_Base.png", "Product_Outfit_RetroSummoner_Female_Base.png"}},
-				{name = "Retro Warrior", thingId = {male=962,female=963}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 870, icons = {"Product_Outfit_RetroWarrior_Male_Base.png", "Product_Outfit_RetroWarrior_Female_Base.png"}},
-				--Pharaoh
-				{name = "Full Pharaoh Outfit", thingId = {male=955,female=956}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 570, icons = {"Product_Outfit_Pharaoh_male_Full.png", "Product_Outfit_Pharaoh_female_Full.png"}},
-				{name = "Pharaoh Outfit", thingId = {male=955,female=956}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 390, icons = {"Product_Outfit_Pharaoh_male_Base.png", "Product_Outfit_Pharaoh_female_Base.png"}},
-				{name = "Pharaoh Outfit Addon 1", thingId = {male=955,female=956}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Pharaoh_male_Addon1.png", "Product_Outfit_Pharaoh_female_Addon1.png"}},
-				{name = "Pharaoh Outfit Addon 2", thingId = {male=955,female=956}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Pharaoh_male_Addon1.png", "Product_Outfit_Pharaoh_female_Addon2.png"}},
-				--Groove Keeper
-				{name = "Full Groove Keeper Outfit", thingId = {male=908,female=909}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 870, icons = {"Product_Outfit_AntlerDruid_male_Full.png", "Product_Outfit_AntlerDruid_female_Full.png"}},
-				{name = "Groove Keeper Outfit", thingId = {male=899,female=900}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 690, icons = {"Product_Outfit_AntlerDruid_male_Base.png", "Product_Outfit_AntlerDruid_female_Base.png"}},
-				{name = "Groove Keeper Addon 1", thingId = {male=899,female=900}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_AntlerDruid_male_Addon1.png", "Product_Outfit_AntlerDruid_female_Addon1.png"}},
-				{name = "Groove Keeper Addon 2", thingId = {male=899,female=900}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_AntlerDruid_male_Addon2.png", "Product_Outfit_AntlerDruid_female_Addon2.png"}},
-				--Lupine Wardem
-				{name = "Full Lupine Wardem Outfit", thingId = {male=899,female=900}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 840, icons = {"Product_Outfit_LupinWarden_male_Full.png", "Product_Outfit_LupinWarden_female_Full.png"}},
-				{name = "Lupine Wardem Outfit", thingId = {male=899,female=900}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 660, icons = {"Product_Outfit_LupinWarden_male_Base.png", "Product_Outfit_LupinWarden_female_Base.png"}},
-				{name = "Lupine Wardem Addon 1", thingId = {male=899,female=900}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_LupinWarden_male_Addon1.png", "Product_Outfit_LupinWarden_female_Addon1.png"}},
-				{name = "Lupine Wardem Addon 2", thingId = {male=899,female=900}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_LupinWarden_male_Addon2.png", "Product_Outfit_LupinWarden_female_Addon1.png"}},
-		    	--Arena Champion
-				{ name = "Full Arena Champion Outfit", thingId = { male = 884, female = 885 }, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 870, icons = {"Product_Outfit_ArenaChampion_Male_Full.png", "Product_Outfit_ArenaChampion_Female_Full.png"}},
-				{ name = "Arena Champion Outfit", thingId = { male = 884, female = 885 }, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 690, icons = {"Product_Outfit_ArenaChampion_Male_Base.png", "Product_Outfit_ArenaChampion_Female_Base.png"}},
-				{ name = "Arena Champion Outfit Addon 1", thingId = { male = 884, female = 885 }, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Beastmaster_Male_Addon1.png", "Product_Outfit_Beastmaster_Female_Addon1.png"}},
-				{ name = "Arena Champion Outfit Addon 2", thingId = { male = 884, female = 885 }, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Beastmaster_Male_Addon2.png", "Product_Outfit_Beastmaster_Female_Addon2.png"}},
-				--Philosopher
-				{name = "Full Philosopher Outfit", thingId = {male=873,female=874}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 750, icons = {"Product_Outfit_Professor_Male_Full.png", "Product_Outfit_Professor_Female_Full.png"}},
-				{name = "Philosopher Outfit", thingId = {male=873,female=874}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 570, icons = {"Product_Outfit_Professor_Male_Base.png", "Product_Outfit_Professor_Female_Base.png"}},
-				{name = "Philosopher Outfit Addon 1", thingId = {male=873,female=874}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Professor_Male_Addon1.png", "Product_Outfit_Professor_Female_Addon1.png"}},
-				{name = "Philosopher Outfit Addon 2", thingId = {male=873,female=874}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Professor_Male_Addon1.png", "Product_Outfit_Professor_Female_Addon2.png"}},
-				--Winter Warden
-				{name = "Full Winter Warden Outfit", thingId = {male=853,female=852}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 870,  icons = {"Product_Outfit_WinterWarden_Male_Full.png", "Product_Outfit_WinterWarden_Female_Full.png"}},
-				{name = "Winter Warden Outfit", thingId = {male=853,female=852}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 690, icons = {"Product_Outfit_WinterWarden_Male_Base.png", "Product_Outfit_WinterWarden_Female_Base.png"}},
-				{name = "Winter Warden Outfit Addon 1", thingId = {male=853,female=852}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_WinterWarden_Male_Addon1.png", "Product_Outfit_WinterWarden_Female_Addon1.png"}},
-				{name = "Winter Warden Outfit Addon 2", thingId = {male=853,female=852}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_WinterWarden_Male_Addon2.png", "Product_Outfit_WinterWarden_Female_Addon2.png"}},
-				--Royal Pumpkin
-				{name = "Full Royal Pumpkin Outfit", thingId = {male=760,female=759}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 640, icons = {"Product_Outfit_RoyalPumpkin_Male_Full.png", "Product_Outfit_RoyalPumpkin_Female_Full.png"}},
-				{name = "Royal Pumpkin Outfit", thingId = {male=760,female=759}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 660, icons = {"Product_Outfit_RoyalPumpkin_Male_Base.png", "Product_Outfit_RoyalPumpkin_Female_Base.png"}},
-				{name = "Royal Pumpkin Outfit Addon 1", thingId = {male=760,female=759}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_RoyalPumpkin_Male_Addon1.png", "Product_Outfit_RoyalPumpkin_Female_Addon2.png"}},
-				{name = "Royal Pumpkin Outfit Addon 2", thingId = {male=760,female=759}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_RoyalPumpkin_Male_Addon2.png", "Product_Outfit_RoyalPumpkin_Female_Addon2.png"}},
-				--Sea Dog
-				{name = "Full Sea Dog Outfit", thingId = {male=750,female=749}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 600, icons = {"Product_Outfit_SeaDog_Male_Full.png", "Product_Outfit_SeaDog_Female_Full.png"}},
-				{name = "Sea Dog Outfit", thingId = {male=750,female=749}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 420, icons = {"Product_Outfit_SeaDog_Male_Base.png", "Product_Outfit_SeaDog_Female_Base.png"}},
-				{name = "Sea Dog Outfit Addon 1", thingId = {male=750,female=749}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_SeaDog_Male_Addon1.png", "Product_Outfit_SeaDog_Female_Addon1.png"}},
-				{name = "Sea Dog Outfit Addon 2", thingId = {male=750,female=749}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_SeaDog_Male_Addon2.png", "Product_Outfit_SeaDog_Female_Addon2.png"}},
-				--Champion
-				{name = "Full Champion Outfit", thingId = {male=633,female=632}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 570, icons = {"Product_Outfit_Champion_Male_Full.png", "Product_Outfit_Champion_Female_Full.png"}},
-				{name = "Champion Outfit", thingId = {male=633,female=632}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 390, icons = {"Product_Outfit_Champion_Male_Base.png", "Product_Outfit_Champion_Female_Base.png"}},
-				{name = "Champion Outfit Addon 1", thingId = {male=633,female=632}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Champion_Male_Addon1.png", "Product_Outfit_Champion_Female_Addon1.png"}},
-				{name = "Champion Outfit Addon 2", thingId = {male=633,female=632}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Champion_Male_Addon2.png", "Product_Outfit_Champion_Female_Addon2.png"}},
-				--Conjurer
-				{name = "Full Conjurer Outfit", thingId = {male=634,female=635}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 720, icons = {"Product_Outfit_Conjurer_Male_Full.png", "Product_Outfit_Conjurer_Female_Full.png"}},
-				{name = "Conjurer Outfit", thingId = {male=634,female=635}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 540, icons = {"Product_Outfit_Conjurer_Male_Base.png", "Product_Outfit_Conjurer_Female_Base.png"}},
-				{name = "Conjurer Outfit Addon 1", thingId = {male=634,female=635}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Conjurer_Male_Addon1.png", "Product_Outfit_Conjurer_Female_Addon1.png"}},
-				{name = "Conjurer Outfit Addon 2", thingId = {male=634,female=635}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Conjurer_Male_Addon2.png", "Product_Outfit_Conjurer_Female_Addon2.png"}},
-				--Beast Master
-				{name = "Full Beastmaster Outfit", thingId = {male=637,female=636}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 870, icons = {"Product_Outfit_Beastmaster_Male_Full.png", "Product_Outfit_Beastmaster_Female_Full.png"}},
-				{name = "Beastmaster Outfit", thingId = {male=637,female=636}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 690, icons = {"Product_Outfit_Beastmaster_Male_Base.png", "Product_Outfit_Beastmaster_Female_Base.png"}},
-				{name = "Beastmaster Outfit Addon 1", thingId = {male=637,female=636}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Beastmaster_Male_Addon1.png", "Product_Outfit_Beastmaster_Female_Addon1.png"}},
-				{name = "Beastmaster Outfit Addon 2", thingId = {male=637,female=637}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Beastmaster_Male_Addon2.png", "Product_Outfit_Beastmaster_Female_Addon2.png"}},
-				--Chaos Acolyte
-				{name = "Full Chaos Acolyte Outfit", thingId = {male=665,female=664}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 600, icons = {"Product_Outfit_ChaosAcolyte_Male_Full.png", "Product_Outfit_ChaosAcolyte_Female_Full.png"}},
-				{name = "Chaos Acolyte Outfit", thingId = {male=665,female=664}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 420, icons = {"Product_Outfit_ChaosAcolyte_Male_Base.png", "Product_Outfit_ChaosAcolyte_Female_Base.png"}},
-				{name = "Chaos Acolyte Outfit Addon 1", thingId = {male=665,female=664}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_ChaosAcolyte_Male_Addon1.png", "Product_Outfit_ChaosAcolyte_Female_Addon1.png"}},
-				{name = "Chaos Acolyte Outfit Addon 2", thingId = {male=665,female=664}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_ChaosAcolyte_Male_Addon2.png", "Product_Outfit_ChaosAcolyte_Female_Addon2.png"}},
-				--Death Herald
-				{name = "Full Death Herald Outfit", thingId = {male=667,female=666}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 600, icons = {"Product_Outfit_DeathHerald_Male_Full.png", "Product_Outfit_DeathHerald_Female_Full.png"}},
-				{name = "Death Herald Outfit", thingId = {male=667,female=666}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 420, icons = {"Product_Outfit_DeathHerald_Male_Base.png", "Product_Outfit_DeathHerald_Female_Base.png"}},
-				{name = "Death Herald Outfit Addon 1", thingId = {male=667,female=666}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_DeathHerald_Male_Addon1.png", "Product_Outfit_DeathHerald_Female_Addon1.png"}},
-				{name = "Death Herald Outfit Addon 2", thingId = {male=667,female=666}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_DeathHerald_Male_Addon2.png", "Product_Outfit_DeathHerald_Female_Addon2.png"}},
-				--Ranger
-				{name = "Full Ranger Outfit", thingId = {male=684,female=683}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 750, icons = {"Product_Outfit_Ranger_Male_Full.png", "Product_Outfit_Ranger_Female_Full.png"}},
-				{name = "Ranger Outfit", thingId = {male=684,female=683}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 570, icons = {"Product_Outfit_Ranger_Male_Base.png", "Product_Outfit_Ranger_Female_Base.png"}},
-				{name = "Ranger Outfit Addon 1", thingId = {male=684,female=683}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Ranger_Male_Addon1.png", "Product_Outfit_Ranger_Female_Addon1.png"}},
-				{name = "Ranger Outfit Addon 2", thingId = {male=684,female=683}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Ranger_Male_Addon2.png", "Product_Outfit_Ranger_Female_Addon2.png"}},			
-				--Ceremonial Garb
-				{name = "Full Ceremonial Garb Outfit", thingId = {male=695,female=694}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 750, icons = {"Product_Outfit_CeremonialGarb_Male_Full.png", "Product_Outfit_CeremonialGarb_Female_Full.png"}},
-				{name = "Ceremonial Garb Outfit", thingId = {male=695,female=694}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 570, icons = {"Product_Outfit_CeremonialGarb_Male_Base.png", "Product_Outfit_CeremonialGarb_Female_Base.png"}},
-				{name = "Ceremonial Garb Outfit Addon 1", thingId = {male=695,female=694}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_CeremonialGarb_Male_Addon1.png", "Product_Outfit_CeremonialGarb_Female_Addon1.png"}},
-				{name = "Ceremonial Garb Outfit Addon 2", thingId = {male=695,female=694}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_CeremonialGarb_Male_Addon2.png", "Product_Outfit_CeremonialGarb_Female_Addon2.png"}},
-				--Puppeteer
-				{name = "Full Puppeteer Outfit", thingId = {male=697,female=696}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 870, icons = {"Product_Outfit_Puppeteer_Male_Full.png", "Product_Outfit_Puppeteer_Female_Full.png"}},
-				{name = "Puppeteer Outfit", thingId = {male=697,female=696}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 690, icons = {"Product_Outfit_Puppeteer_Male_Base.png", "Product_Outfit_Puppeteer_Female_Base.png"}},
-				{name = "Puppeteer Outfit Addon 1", thingId = {male=697,female=696}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Puppeteer_Male_Addon1.png", "Product_Outfit_Puppeteer_Female_Addon1.png"}},
-				{name = "Puppeteer Outfit Addon 2", thingId = {male=697,female=696}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Puppeteer_Male_Addon2.png", "Product_Outfit_Puppeteer_Female_Addon2.png"}},
-				--Spirit Caller
-				{name = "Full Spirit Caller Outfit", thingId = {male=699,female=698}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 600, icons = {"Product_Outfit_SpiritCaller_Male_Full.png", "Product_Outfit_SpiritCaller_Female_Full.png"}},
-				{name = "Spirit Caller Outfit", thingId = {male=699,female=698}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 420, icons = {"Product_Outfit_SpiritCaller_Male_Base.png", "Product_Outfit_SpiritCaller_Female_Base.png"}},
-				{name = "Spirit Caller Outfit Addon 1", thingId = {male=699,female=698}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_SpiritCaller_Male_Addon1.png", "Product_Outfit_SpiritCaller_Female_Addon1.png"}},
-				{name = "Spirit Caller Outfit Addon 2", thingId = {male=699,female=698}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_SpiritCaller_Male_Addon2.png", "Product_Outfit_SpiritCaller_Female_Addon2.png"}},
-				--Evoker
-				{name = "Full Evoker Outfit", thingId = {male=725,female=724}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 840, icons = {"Product_Outfit_Evoker_Male_Full.png", "Product_Outfit_Evoker_Female_Full.png"}},
-				{name = "Evoker Outfit", thingId = {male=725,female=724}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 660, icons = {"Product_Outfit_Evoker_Male_Base.png", "Product_Outfit_Evoker_Female_Base.png"}},
-				{name = "Evoker Outfit Addon 1", thingId = {male=725,female=724}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Evoker_Male_Addon1.png", "Product_Outfit_Evoker_Female_Addon1.png"}},
-				{name = "Evoker Outfit Addon 2", thingId = {male=725,female=724}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_Evoker_Male_Addon2.png", "Product_Outfit_Evoker_Female_Addon2.png"}},			
-				--Seaweaver
-				{name = "Full Seaweaver Outfit", thingId = {male=733,female=732}, addon = 3, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 570, icons = {"Product_Outfit_SeaWeaver_Male_Full.png", "Product_Outfit_SeaWeaver_Female_Full.png"}},
-				{name = "Seaweaver Outfit", thingId = {male=733,female=732}, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT, price = 390, icons = {"Product_Outfit_SeaWeaver_Male_Base.png", "Product_Outfit_SeaWeaver_Female_Base.png"}},
-				{name = "Seaweaver Outfit Addon 1", thingId = {male=733,female=732}, addon = 1, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_SeaWeaver_Male_Addon1.png", "Product_Outfit_SeaWeaver_Female_Addon1.png"}},
-				{name = "Seaweaver Outfit Addon 2", thingId = {male=733,female=732}, addon = 2, type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON, price = 120, icons = {"Product_Outfit_SeaWeaver_Male_Addon2.png", "Product_Outfit_SeaWeaver_Female_Addon2.png"}},
-			}
-	},
-	
-	{
-		name = "House Equipment",
-		state = GameStore.States.STATE_NONE,
-		description = "Buy exceptional equipment to upgrade your Tibia House",
-		icons = {"Category_HouseEquipment.png"},
-		rookgaard = true,
-		offers = {
-				{name = "Alchemistic Cabinet", thingId = 31192, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 100, icons = {"Product_HouseEquipment_alchemisticcabinet.png"}},
-				{name = "Alchemistic Bookstand", thingId = 31211, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 100, icons = {"Product_HouseEquipment_alchemisticbookstand.png"}},
-				{name = "Alchemistic Chair", thingId = 31258, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 50, icons = {"Product_HouseEquipment_alchemisticchair.png"}},
-				{name = "Alchemistic Scales", thingId = 31215, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 120, icons = {"Product_HouseEquipment_alchemisticscales.png"}},
-				{name = "Alchemist Table", thingId = 31194, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 80, icons = {"Product_HouseEquipment_alchemistictable.png"}},
-				{name = "Pile of Alchemist Books", thingId = 31219, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 120, icons = {"Product_HouseEquipment_pileofalchemisticbooks.png"}},
-				{name = "Alchemist Cup Board", thingId = 31221, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 50, icons = {"Product_HouseEquipment_alchemisticcupboard.png"}},
-				{name = "Light of Change", thingId = 31201, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 120, icons = {"Product_HouseEquipment_lightofchange.png"}},
-				{name = "Torch of Change", thingId = 31207, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 120, icons = {"Product_HouseEquipment_torchofchange.png"}},
-				{name = "Ferumbras Bust", thingId = 31305, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 70, icons = {"Product_HouseEquipment_ferumbrasbust.png"}},
-				{name = "Queen Eloise Bust", thingId = 31307, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 50, icons = {"Product_HouseEquipment_queeneloisebust.png"}},
-				{name = "King Tibianus Bust", thingId = 31309, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 50, icons = {"Product_HouseEquipment_kingtibianusbust.png"}},
-				{name = "Arrival At Thais Painting", thingId = 31226, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 50, icons = {"Product_HouseEquipment_arrivalatthaispainting.png"}},
-				{name = "Tibia Street Painting", thingId = 31228, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 100, icons = {"Product_HouseEquipment_tibiastreetspainting.png"}},
-				{name = "Ferumbras Portrait", thingId = 31230, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 100, icons = {"Product_HouseEquipment_ferumbrasportrait.png"}},
-				{name = "Wheat Carpet", thingId = 29433, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 30, icons = {"Product_HouseEquipment_Carpet23.png"}},
-				{name = "Crested Carpet", thingId = 29435, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 25, icons = {"Product_HouseEquipment_Carpet24.png"}},
-				{name = "Decorated Carpet", thingId = 29437, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 35, icons = {"Product_HouseEquipment_Carpet25.png"}},
-				{name = "Ornate Table", thingId = 29443, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 50, icons = {"Product_HouseEquipment_EgyptianFurniture_Table.png"}},
-				{name = "Ornate Chair", thingId = 29439, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 50, icons = {"Product_HouseEquipment_EgyptianFurniture_Chair.png"}},
-				{name = "Ornate Chest", thingId = 29445, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 80, icons = {"Product_HouseEquipment_EgyptianFurniture_Chest.png"}},
-				{name = "Ornate Cabinet", thingId = 29447, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 100, icons = {"Product_HouseEquipment_EgyptianFurniture_Cupboard.png"}},
-				{name = "Terrarium Snake", thingId = 29451, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 180, icons = {"Product_HouseEquipment_Housepet_Snake.png"}},
-				{name = "Demon Pit", thingId = 29455, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 250, icons = {"Product_HouseEquipment_Housepet_LilDemon.png"}},
-				{name = "Verdant Chair", thingId = 29336, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 50, icons = {"Product_HouseEquipment_NaturalFurniture_Chair.png"}},
-				{name = "Verdant Cabinet", thingId = 29340, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 100, icons = {"Product_HouseEquipment_NaturalFurniture_Cabinet.png"}},
-				{name = "Verdant Trunk", thingId = 29346, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 50, icons = {"Product_HouseEquipment_NaturalFurniture_Chest.png"}},
-				{name = "Verdant Table", thingId = 29347, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 80, icons = {"Product_HouseEquipment_NaturalFurniture_Table.png"}},
-				{name = "Venoream Table Clock", thingId = 29347, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 120, icons = {"Product_HouseEquipment_FancyClock.png"}},
-				{name = "Verdant Carpet", thingId = 29349, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 30, icons = {"Product_HouseEquipment_Carpet_18.png"}},
-				{name = "Shaggy Carpet", thingId = 29351, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 30, icons = {"Product_HouseEquipment_Carpet_19.png"}},
-				{name = "Mystic Carpet", thingId = 29353, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 35, icons = {"Product_HouseEquipment_Carpet_20.png"}},
-				{name = "Wooden Planks", thingId = 29358, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 25, icons = {"Product_HouseEquipment_Carpet_22.png"}},
-				{name = "Stone Tiles", thingId = 29355, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 25, icons = {"Product_HouseEquipment_Carpet_21.png"}},
-				{name = "Hrodmiran Weapons Rack", thingId = 29316, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 90, icons = {"Product_HouseEquipment_HrodmirianWeaponRack.png"}},
-				{name = "Bath Tube", thingId = 29311, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 250, icons = {"Product_HouseEquipment_Bathtub.png"}},
-				{name = "Terrarium Spider", thingId = 29313, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 180, icons = {"Product_HouseEquipment_BabyGiantSpider.png"}},
-				{name = "Daily Reward Shrine", thingId = 29020, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 150, icons = {"Product_HouseEquipment_DailyRewardShrine.png"}},
-				{name = "Shiny Daily Reward Shrine", thingId = 29023, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 150, icons = {"Product_HouseEquipment_ShinyDailyRewardShrine.png"}},
-				{name = "Health Cask", thingId = 28555, count = 1000, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 4, icons = {"Health_Cask.png"}},
-				{name = "Strong Health Cask", thingId = 28556, count = 1000, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 9, icons = {"Strong_Health_Cask.png"}},
-				{name = "Great Health Cask", thingId = 28557, count = 1000, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 18, icons = {"Great_Health_Cask.png"}},
-				{name = "Ultimate Health Cask", thingId = 28558, count = 1000, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 29, icons = {"Ultimate_Health_Cask.png"}},
-				{name = "Supreme Health Cask", thingId = 28559, count = 1000, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 47, icons = {"Supreme_Health_Cask.png"}},
-                {name = "Mana Cask", thingId = 28565, count = 1000, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 4, icons = {"Mana_Cask.png"}},
-				{name = "Strong Mana Cask", thingId = 28566, count = 1000, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 7, icons = {"Strong_Mana_Cask.png"}},
-				{name = "Great Mana Cask", thingId = 28567, count = 1000, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 11, icons = {"Great_Mana_Cask.png"}},
-				{name = "Ultimate Mana Cask", thingId = 28568, count = 1000, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 33, icons = {"Ultimate_Mana_Cask.png"}},
-				{name = "Great Spirit Cask", thingId = 28575, count = 1000, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 18, icons = {"Great_Spirit_Cask.png"}},
-				{name = "Ultimate Spirit Cask", thingId = 28576, count = 1000, type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, price = 18, icons = {"Ultimate_Spirit_Cask.png"}},
-				{name = "Vengothic Chair", description = "Buy an incredible Vengothic Chair to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27897, count = 1, price = 50, icons = {"Product_HouseEquipment_VengothicFurniture_Chair.png"}},
-				{name = "Vengothic Chest", description = "Buy an incredible Vengothic Chest to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27905, count = 1, price = 80, icons = {"Product_HouseEquipment_VengothicFurniture_Chest.png"}},
-				{name = "Vengothic Cabinet", description = "Buy an incredible Vengothic Cabinet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27903, count = 1, price = 100, icons = {"Product_HouseEquipment_VengothicFurniture_Cupboard.png"}},
-				{name = "Vengothic Table", description = "Buy an incredible Vengothic Table to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27901, count = 1, price = 50, icons = {"Product_HouseEquipment_VengothicFurniture_Table.png"}},
-				{name = "Vengothic Lamp", description = "Buy an incredible Vengothic Lamp to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27886, count = 1, price = 180, icons = {"Product_HouseEquipment_VengothicLamp.png"}},
-				{name = "Chamaleon", description = "Buy an incredible Chamaleon to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27889, count = 1, price = 250, icons = {"Product_HouseEquipment_Chameleon.png"}},
-				{name = "Blooming Cactus", description = "Buy an incredible Blooming Cactus to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27892, count = 1, price = 50, icons = {"Product_HouseEquipment_BloomingCactus.png"}},
-				{name = "Bitter-Smack Leaf", description = "Buy an incredible Bitter-Smack Leaf to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27893, count = 1, price = 50, icons = {"Product_HouseEquipment_BitterSmackLeaf.png"}},
-				{name = "Pink Roses", description = "Buy an incredible Pink Roses to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27894, count = 1, price = 50, icons = {"Product_HouseEquipment_PinkRoses.png"}},
-				{name = "Red Roses", description = "Buy an incredible Red Roses to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27895, count = 1, price = 50, icons = {"Product_HouseEquipment_RedRoses.png"}},
-				{name = "Yellow Roses", description = "Buy an incredible Yellow Roses to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 2789, count = 1, price = 50, icons = {"Product_HouseEquipment_YellowRoses.png"}},
-				{name = "Parrot", description = "Buy an incredible Parrot to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27100, count = 1, price = 180, icons = {"Product_HouseEquipment_Housepet_Parrot.png"}},
-				{name = "Skull Lamp", description = "Buy an incredible Skull Lamp to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27102, count = 1, price = 90, icons = {"Product_HouseEquipment_Lamp_Skull.png"}},
-				{name = "Flowery Carpet", description = "Buy an incredible Flowery Carpet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27084, count = 1, price = 35, icons = {"Product_HouseEquipment_Carpet_10.png"}},
-				{name = "Colourful Carpet", description = "Buy an incredible Colourful Carpet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27085, count = 1, price = 35, icons = {"Product_HouseEquipment_Carpet_11.png"}},
-				{name = "Striped Carpet", description = "Buy an incredible Striped Carpet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27086, count = 1, price = 35, icons = {"Product_HouseEquipment_Carpet_12.png"}},
-				{name = "Patterned Carpet", description = "Buy an incredible Patterned Carpet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27089, count = 1, price = 30, icons = {"Product_HouseEquipment_Carpet_15.png"}},
-				{name = "Fur Carpet", description = "Buy an incredible Fur Carpet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27087, count = 1, price = 30, icons = {"Product_HouseEquipment_Carpet_13.png"}},
-				{name = "Diamond Carpet", description = "Buy an incredible Diamond Carpet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27088, count = 1, price = 30, icons = {"Product_HouseEquipment_Carpet_14.png"}},
-				{name = "Night Sky Carpet", description = "Buy an Night Sky Carpet Carpet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27090, count = 1, price = 30, icons = {"Product_HouseEquipment_Carpet_16.png"}},
-				{name = "Star Carpet", description = "Buy an incredible Star Carpet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27091, count = 1, price = 30, icons = {"Product_HouseEquipment_Carpet_17.png"}},
-				{name = "Gilded Imbuing Shrine", description = "Buy an incredible Gilded Imbuing Shrine to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27850, count = 1, price = 200, icons = {"Product_HouseEquipment_GildedImbuingShrine.png"}},
-				{name = "Imbuing Shrine", description = "Buy an incredible Imbuing Shrine to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 27728, count = 1, price = 150, icons = {"Product_HouseEquipment_ImbuingShrine.png"}},
-				{name = "Fish Tank", description = "Buy an incredible Fish Tank to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26347, count = 1, price = 180, icons = {"Product_HouseEquipment_Housepet_FishTank.png"}},
-				{name = "Dog House", description = "Buy an incredible Dog House to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26364, count = 1, price = 150, icons = {"Product_HouseEquipment_Housepet_DogHouse.png"}},
-				{name = "Golden Dragon Tapestry", description = "Buy an incredible Golden Dragon Tapestry to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26379, count = 1, price = 70, icons = {"Product_HouseEquipment_Tapestry_04.png"}},
-				{name = "Sword Tapestry", description = "Buy an incredible Sword Tapestry to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26380, count = 1, price = 60, icons = {"Product_HouseEquipment_Tapestry_05.png"}},
-				{name = "Brocade Tapestry", description = "Buy an incredible Brocade Tapestry to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26381, count = 1, price = 50, icons = {"Product_HouseEquipment_Tapestry_06.png"}},
-				{name = "Rustic Cabinet", description = "Buy an incredible Rustic Cabinet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26356, count = 1, price = 100, icons = {"Product_HouseEquipment_RusticFurniture_Cabinet.png"}},
-				{name = "Rustic Chair", description = "Buy an incredible Rustic Chair to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26349, count = 1, price = 50, icons = {"Product_HouseEquipment_RusticFurniture_Chair.png"}},
-				{name = "Rustic Trunk", description = "Buy an incredible Rustic Trunk to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26358, count = 1, price = 80, icons = {"Product_HouseEquipment_RusticFurniture_Chest.png"}},
-				{name = "Rustic Table", description = "Buy an incredible Rustic Table to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26354, count = 1, price = 50, icons = {"Product_HouseEquipment_RusticFurniture_Table.png"}},
-				{name = "Crimson Carpet", description = "Buy an incredible Crimson Carpet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26371, count = 1, price = 35, icons = {"Product_HouseEquipment_Carpet_04.png"}},
-				{name = "Azure Carpet", description = "Buy an incredible Azure Carpet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26372, count = 1, price = 35, icons = {"Product_HouseEquipment_Carpet_05.png"}},
-				{name = "Emerald Carpet", description = "Buy an incredible Emerald Carpet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26373, count = 1, price = 30, icons = {"Product_HouseEquipment_Carpet_06.png"}},
-				{name = "Light Parquet", description = "Buy an incredible Light Parquet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26374, count = 1, price = 30, icons = {"Product_HouseEquipment_Carpet_07.png"}},
-				{name = "Dark Parquet", description = "Buy an incredible Dark Parquet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26375, count = 1, price = 30, icons = {"Product_HouseEquipment_Carpet_08.png"}},
-				{name = "Marble Floor", description = "Buy an incredible Marble Floor to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26370, count = 1, price = 30, icons = {"Product_HouseEquipment_Carpet_09.png"}},
-				{name = "Baby Dragon", description = "Buy an incredible Baby Dragon to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26098, count = 1, price = 250, icons = {"Product_HouseEquipment_Housepet_BabyDragon.png"}},
-				{name = "Cat in a Basket", description = "Buy an incredible Cat in a Basket to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26107, count = 1, price = 150, icons = {"Product_HouseEquipment_Housepet_Cat.png"}},
-				{name = "Hamster in a Wheel", description = "Buy an incredible Hamster in a Wheel to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26100, count = 1, price = 180, icons = {"Product_HouseEquipment_Housepet_Hamster.png"}},
-				{name = "Magnificent Cabinet", description = "Buy an incredible Magnificent Cabinet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26075, count = 1, price = 100, icons = {"Product_HouseEquipment_BaroqueFurniture_Cabinet.png"}},
-				{name = "Magnificent Chair", description = "Buy an incredible Magnificent chair to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26059, count = 1, price = 60, icons = {"Product_HouseEquipment_BaroqueFurniture_Chair.png"}},
-				{name = "Magnificent Trunk", description = "Buy an incredible Magnificent Trunk to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26083, count = 1, price = 70, icons = {"Product_HouseEquipment_BaroqueFurniture_Chest.png"}},
-				{name = "Magnificent Table", description = "Buy an incredible Magnificent Table to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26073, count = 1, price = 60, icons = {"Product_HouseEquipment_BaroqueFurniture_Table.png"}},
-				{name = "Ferocious Cabinet", description = "Buy an incredible Ferocious Cabinet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26077, count = 1, price = 110, icons = {"Product_HouseEquipment_TortureChamberFurniture_Cabinet.png"}},
-				{name = "Ferocious Chair", description = "Buy an incredible Ferocious Chair to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26063, count = 1, price = 50, icons = {"Product_HouseEquipment_TortureChamberFurniture_Chair.png"}},
-				{name = "Ferocious Trunk", description = "Buy an incredible Ferocious Trunk to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26079, count = 1, price = 80, icons = {"Product_HouseEquipment_TortureChamberFurniture_Chest.png"}},
-				{name = "Ferocious Table", description = "Buy an incredible Ferocious Table to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26067, count = 1, price = 50, icons = {"Product_HouseEquipment_TortureChamberFurniture_Table.png"}},
-				{name = "Yalaharian Carpet", description = "Buy an incredible Yalaharian Carpet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26109, count = 1, price = 35, icons = {"Product_HouseEquipment_Carpet1.png"}},
-				{name = "White Fur Carpet", description = "Buy an incredible White Fur Carpet to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26110, count = 1, price = 30, icons = {"Product_HouseEquipment_Carpet2.png"}},
-				{name = "Bamboo Mat", description = "Buy an incredible Bamboo Mat to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 2611, count = 26111, price = 25, icons = {"Product_HouseEquipment_Carpet3.png"}},
-				{name = "Lit Protectress Lamp", description = "Buy an incredible Protectress Lamp to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26094, count = 1, price = 90, icons = {"Product_HouseEquipment_Lamp_Goddess.png"}},
-				{name = "Lit Predator Lamp", description = "Buy an incredible Predator Lamp to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26090, count = 1, price = 60, icons = {"Product_HouseEquipment_Lamp_Leopard.png"}},
-				{name = "Royal Mailbox", description = "Buy an incredible Royal Mailbox to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26055, count = 1, price = 150, icons = {"Product_HouseEquipment_Mailbox_Golden.png"}},
-				{name = "Ornate Mailbox", description = "Buy an incredible Ornate Mailbox to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26057, count = 1, price = 200, icons = {"Product_HouseEquipment_Mailbox_Standard.png"}},
-				{name = "Lordly Tapestry", description = "Buy an incredible Lordly Tapestry to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26104, count = 1, price = 50, icons = {"Product_HouseEquipment_Tapestry_01.png"}},
-				{name = "Menacing Tapestry", description = "Buy an incredible Menacing Tapestry to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26105, count = 1, price = 70, icons = {"Product_HouseEquipment_Tapestry_02.png"}},
-				{name = "All-Seeing Tapestry", description = "Buy an incredible All-Seeing Tapestry to decorate your home.", type = GameStore.OfferTypes.OFFER_TYPE_HOUSE, thingId = 26106, count = 1, price = 60, icons = {"Product_HouseEquipment_Tapestry_03.png"}},
-
-	},
-	},
-
-	{
-		name = "XP Boost",
-		state = GameStore.States.STATE_NONE,
-		description = "Buy your character a boost to speed up your character development.",
-		rookgaard = true,
-		icons = {"Category_Boosts.png"},
-		offers = {
-			{name = "XP Boost 50%", type = GameStore.OfferTypes.OFFER_TYPE_EXPBOOST, price = 30, icons = {"xpboosticon.png"}},
-		}
-	},
-	
-	{
-		name = "Useful Things",
-		state = GameStore.States.STATE_NONE,
-        description = "Buy your character one or more of the helpful items offered here.",
-		rookgaard = true,
-		icons = {"Category_Convenience.png"},
-		offers = {
-			{name = "Prey Bonus Reroll", count = 1, type = GameStore.OfferTypes.OFFER_TYPE_PREYBONUS, price = 5, icons = {"Product_UsefulThings_PreyBonusReroll.png"}},
-			{name = "5x Prey Bonus Reroll", count = 5, type = GameStore.OfferTypes.OFFER_TYPE_PREYBONUS, price = 25, icons = {"Product_UsefulThings_PreyBonusReroll.png"}},
-			{name = "Permanent Prey Slot", type = GameStore.OfferTypes.OFFER_TYPE_PREYSLOT, price = 450, icons = {"Product_UsefulThings_PreyBonusReroll.png"}},
-			{name = "Temple Teleport", type = GameStore.OfferTypes.OFFER_TYPE_TEMPLE, price = 25, icons = {"Product_Transportation_TempleTeleport.png"}},
-			{name = "Gold Pounch", thingId = 26377, count = 1, type = GameStore.OfferTypes.OFFER_TYPE_ITEM, price = 900, icons = {"Product_MagicCoinPurse.png"}, description = "With Gold Pounch you can carry the amount of gold without having to keep many knapsacks in the backpack, this product allows you to be charged as much gold as your ability allows."},
-		}
-	},
-	
-}
-
--- Non-Editable
-local runningId = 1
+-- Each outfit must be uniquely identified to distinguish between addons.
+-- Here we dynamically assign ids for outfits. These ids must be unique.
+local runningId = 45000
 for k, category in ipairs(GameStore.Categories) do
-	if category.offers then
-		for m, offer in ipairs(category.offers) do
-			offer.id = runningId
-			runningId = runningId + 1
-			
-			if not offer.type then
-				offer.type = GameStore.OfferTypes.OFFER_TYPE_NONE
-			end
-		end
-	end
+  if category.name == "Outfits" and category.offers then
+    for m, offer in ipairs(category.offers) do
+      offer.id = runningId
+      runningId = runningId + 1
+
+      if not offer.type then
+        offer.type = GameStore.OfferTypes.OFFER_TYPE_NONE
+      end
+    end
+  end
 end

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1,1156 +1,1230 @@
 -- Please don't edit those information!
 GameStore = {
-	ModuleName = "GameStore",
-	Developer = "Cjaker",
-	Version = "0.3",
-	LastUpdated = "24-09-2016 07:15PM"
+  ModuleName = "GameStore",
+  Developers = { "Cjaker", "metabob" },
+  Version = "0.4",
+  LastUpdated = "15-04-2019 17:40PM"
 }
 
 --== Enums ==--
 GameStore.OfferTypes = {
-	OFFER_TYPE_NONE = 0, -- (this will disable offer)
-	OFFER_TYPE_ITEM = 1,
-	OFFER_TYPE_STACKABLE = 2,
-	OFFER_TYPE_OUTFIT = 3,
-	OFFER_TYPE_OUTFIT_ADDON = 4,
-	OFFER_TYPE_MOUNT = 5,
-	OFFER_TYPE_NAMECHANGE = 6,
-	OFFER_TYPE_SEXCHANGE = 7,
-	OFFER_TYPE_PROMOTION = 8,
-	OFFER_TYPE_HOUSE = 9,
-	OFFER_TYPE_EXPBOOST = 10,
-	OFFER_TYPE_PREYSLOT = 11,
-	OFFER_TYPE_PREYBONUS = 12,
-	OFFER_TYPE_TEMPLE = 13,
-	OFFER_TYPE_BLESSINGS = 14,
-	OFFER_TYPE_PREMIUM = 15,
-	OFFER_TYPE_POUNCH = 16,
-	OFFER_TYPE_ALLBLESSINGS = 17
+  OFFER_TYPE_NONE = 0, -- (this will disable offer)
+  OFFER_TYPE_ITEM = 1,
+  OFFER_TYPE_STACKABLE = 2,
+  OFFER_TYPE_OUTFIT = 3,
+  OFFER_TYPE_OUTFIT_ADDON = 4,
+  OFFER_TYPE_MOUNT = 5,
+  OFFER_TYPE_NAMECHANGE = 6,
+  OFFER_TYPE_SEXCHANGE = 7,
+  OFFER_TYPE_PROMOTION = 8,
+  OFFER_TYPE_HOUSE = 9,
+  OFFER_TYPE_EXPBOOST = 10,
+  OFFER_TYPE_PREYSLOT = 11,
+  OFFER_TYPE_PREYBONUS = 12,
+  OFFER_TYPE_TEMPLE = 13,
+  OFFER_TYPE_BLESSINGS = 14,
+  OFFER_TYPE_PREMIUM = 15,
+  OFFER_TYPE_POUNCH = 16,
+  OFFER_TYPE_ALLBLESSINGS = 17
 }
 
 GameStore.ClientOfferTypes = {
-	CLIENT_STORE_OFFER_OTHER = 0,
-	CLIENT_STORE_OFFER_NAMECHANGE = 1
+  CLIENT_STORE_OFFER_OTHER = 0,
+  CLIENT_STORE_OFFER_NAMECHANGE = 1
 }
 
 GameStore.HistoryTypes = {
-	HISTORY_TYPE_NONE = 0,
-	HISTORY_TYPE_GIFT = 1,
-	HISTORY_TYPE_REFUND = 2
+  HISTORY_TYPE_NONE = 0,
+  HISTORY_TYPE_GIFT = 1,
+  HISTORY_TYPE_REFUND = 2
 }
 
 GameStore.States = {
-	STATE_NONE = 0,
-	STATE_NEW = 1,
-	STATE_SALE = 2,
-	STATE_TIMED = 3
+  STATE_NONE = 0,
+  STATE_NEW = 1,
+  STATE_SALE = 2,
+  STATE_TIMED = 3
 }
 
 GameStore.StoreErrors = {
-	STORE_ERROR_PURCHASE = 0,
-	STORE_ERROR_NETWORK = 1,
-	STORE_ERROR_HISTORY = 2,
-	STORE_ERROR_TRANSFER = 3,
-	STORE_ERROR_INFORMATION = 4
+  STORE_ERROR_PURCHASE = 0,
+  STORE_ERROR_NETWORK = 1,
+  STORE_ERROR_HISTORY = 2,
+  STORE_ERROR_TRANSFER = 3,
+  STORE_ERROR_INFORMATION = 4
 }
 
 GameStore.ServiceTypes = {
-	SERVICE_STANDERD = 0,
-	SERVICE_OUTFITS = 3,
-	SERVICE_MOUNTS = 4,
-	SERVICE_BLESSINGS = 5
+  SERVICE_STANDERD = 0,
+  SERVICE_OUTFITS = 3,
+  SERVICE_MOUNTS = 4,
+  SERVICE_BLESSINGS = 5
 }
 
 GameStore.SendingPackets = {
-	S_CoinBalance = 0xDF, -- 223
-	S_StoreError = 0xE0, -- 224
-	S_RequestPurchaseData = 0xE1, -- 225
-	S_CoinBalanceUpdating = 0xF2, -- 242
-	S_OpenStore = 0xFB, -- 251
-	S_StoreOffers = 0xFC, -- 252
-	S_OpenTransactionHistory = 0xFD, -- 253
-	S_CompletePurchase = 0xFE  -- 254
+  S_CoinBalance = 0xDF, -- 223
+  S_StoreError = 0xE0, -- 224
+  S_RequestPurchaseData = 0xE1, -- 225
+  S_CoinBalanceUpdating = 0xF2, -- 242
+  S_OpenStore = 0xFB, -- 251
+  S_StoreOffers = 0xFC, -- 252
+  S_OpenTransactionHistory = 0xFD, -- 253
+  S_CompletePurchase = 0xFE  -- 254
 }
 
 GameStore.RecivedPackets = {
-	C_StoreEvent = 0xE9, -- 233
-	C_TransferCoins = 0xEF, -- 239
-	C_OpenStore = 0xFA, -- 250
-	C_RequestStoreOffers = 0xFB, -- 251
-	C_BuyStoreOffer = 0xFC, -- 252
-	C_OpenTransactionHistory = 0xFD, -- 253
-	C_RequestTransactionHistory = 0xFE, -- 254
+  C_StoreEvent = 0xE9, -- 233
+  C_TransferCoins = 0xEF, -- 239
+  C_OpenStore = 0xFA, -- 250
+  C_RequestStoreOffers = 0xFB, -- 251
+  C_BuyStoreOffer = 0xFC, -- 252
+  C_OpenTransactionHistory = 0xFD, -- 253
+  C_RequestTransactionHistory = 0xFE, -- 254
 }
 
 GameStore.ExpBoostValues = {
-	[1] = 30,
-	[2] = 45,
-	[3] = 90,
-	[4] = 180,
-	[5] = 360
+  [1] = 30,
+  [2] = 45,
+  [3] = 90,
+  [4] = 180,
+  [5] = 360
 }
 
 GameStore.DefaultValues = {
-	DEFAULT_VALUE_ENTRIES_PER_PAGE	= 16
+  DEFAULT_VALUE_ENTRIES_PER_PAGE = 16
 }
 
 GameStore.DefaultDescriptions = {
-	OUTFIT = {"This outfit looks nice. Only high-class people are able to wear it!",
-		"An outfit that was created to suit you. We are sure you'll like it.",
-		"Legend says only smart people should wear it, otherwise you will burn!"},
-	MOUNT = {"This is a fantastic mount that helps to become faster, try it!",
-		"The first rider of this mount became the leader of his country! legends say that."},
-	NAMECHANGE = {"Are you hunted? Tired of that? Get a new name, a new life!",
-		"A new name to suit your needs!"},
-	SEXCHANGE = {"Bored of your character's sex? Get a new sex for him now!!"},
-	EXPBOOST = {"Are you tired of leveling slow? try it!"},
-	PREYSLOT = {"It's hunting season! Activate a prey to gain a bonus when hunting a certain monster. Every character can purchase one Permanent Prey Slot, which enables the activation of an additional prey. \nIf you activate a prey, you can select one monster out of nine. The bonus for your prey will be selected randomly from one of the following: damage boost, damage reduction, bonus XP, improved loot. The bonus value may range from 5% to 50%. Your prey will be active for 2 hours hunting time: the duration of an active prey will only be reduced while you are hunting."},
-	PREYBONUS = {"You activated a prey but do not like the randomly selected bonus? Roll for a new one! Here you can purchase five Prey Bonus Rerolls! \nA Bonus Reroll allows you to get a bonus with a higher value (max. 50%). The bonus for your prey will be selected randomly from one of the following: damage boost, damage reduction, bonus XP, improved loot. The 2 hours hunting time will start anew once you have rolled for a new bonus. Your prey monster will stay the same."},
-	TEMPLE = {"Need a quick way home? Buy this transportation service to get instantly teleported to your home temple. \n\nNote, you cannot use this service while having a battle sign or a protection zone block. Further, the service will not work in no-logout zones or close to your home temple."}
+  OUTFIT      = { "This outfit looks nice. Only high-class people are able to wear it!",
+             "An outfit that was created to suit you. We are sure you'll like it.",
+             "Legend says only smart people should wear it, otherwise you will burn!" },
+  MOUNT       = { "This is a fantastic mount that helps to become faster, try it!",
+            "The first rider of this mount became the leader of his country! legends say that." },
+  NAMECHANGE  = { "Are you hunted? Tired of that? Get a new name, a new life!",
+                 "A new name to suit your needs!" },
+  SEXCHANGE   = { "Bored of your character's sex? Get a new sex for him now!!" },
+  EXPBOOST    = { "Are you tired of leveling slow? try it!" },
+  PREYSLOT    = { "It's hunting season! Activate a prey to gain a bonus when hunting a certain monster. Every character can purchase one Permanent Prey Slot, which enables the activation of an additional prey. \nIf you activate a prey, you can select one monster out of nine. The bonus for your prey will be selected randomly from one of the following: damage boost, damage reduction, bonus XP, improved loot. The bonus value may range from 5% to 50%. Your prey will be active for 2 hours hunting time: the duration of an active prey will only be reduced while you are hunting." },
+  PREYBONUS   = { "You activated a prey but do not like the randomly selected bonus? Roll for a new one! Here you can purchase five Prey Bonus Rerolls! \nA Bonus Reroll allows you to get a bonus with a higher value (max. 50%). The bonus for your prey will be selected randomly from one of the following: damage boost, damage reduction, bonus XP, improved loot. The 2 hours hunting time will start anew once you have rolled for a new bonus. Your prey monster will stay the same." },
+  TEMPLE      = { "Need a quick way home? Buy this transportation service to get instantly teleported to your home temple. \n\nNote, you cannot use this service while having a battle sign or a protection zone block. Further, the service will not work in no-logout zones or close to your home temple." }
 }
 
 --==Parsing==--
 GameStore.isItsPacket = function(byte)
-	for k, v in pairs(GameStore.RecivedPackets) do
-		if v == byte then
-			return true
-		end
-	end
-	return false
+  for k, v in pairs(GameStore.RecivedPackets) do
+    if v == byte then
+      return true
+    end
+  end
+  return false
+end
+
+local function queueSendStoreAlertToUser(message, delay, playerId, storeErrorCode)
+  storeErrorCode = storeErrorCode and storeErrorCode or  GameStore.StoreErrors.STORE_ERROR_NETWORK
+  addPlayerEvent(sendStoreError, delay, playerId, storeErrorCode, message)
 end
 
 function onRecvbyte(player, msg, byte)
-	if not configManager.getBoolean(STOREMODULES) then return true end
-	if player:getVocation():getId() == 0 and not GameStore.haveCategoryRook() then
-		return player:sendCancelMessage("Store don't have offers for rookgaard citizen.")
-	end
+  if not configManager.getBoolean(STOREMODULES) then return true end
+  if player:getVocation():getId() == 0 and not GameStore.haveCategoryRook() then
+    return player:sendCancelMessage("Store don't have offers for rookgaard citizen.")
+  end
 
-	if byte == GameStore.RecivedPackets.C_StoreEvent then
-		-- Not Used!
-	elseif byte == GameStore.RecivedPackets.C_TransferCoins then
-		parseTransferCoins(player:getId(), msg)
-	elseif byte == GameStore.RecivedPackets.C_OpenStore then
-		parseOpenStore(player:getId(), msg)
-	elseif byte == GameStore.RecivedPackets.C_RequestStoreOffers then
-		parseRequestStoreOffers(player:getId(), msg)
-	elseif byte == GameStore.RecivedPackets.C_BuyStoreOffer then
-		parseBuyStoreOffer(player:getId(), msg)
-	elseif byte == GameStore.RecivedPackets.C_OpenTransactionHistory then
-		parseOpenTransactionHistory(player:getId(), msg)
-	elseif byte == GameStore.RecivedPackets.C_RequestTransactionHistory then
-		parseRequestTransactionHistory(player:getId(), msg)
-	end
-	return true
+  if byte == GameStore.RecivedPackets.C_StoreEvent then
+    -- Not Used!
+  elseif byte == GameStore.RecivedPackets.C_TransferCoins then
+    parseTransferCoins(player:getId(), msg)
+  elseif byte == GameStore.RecivedPackets.C_OpenStore then
+    parseOpenStore(player:getId(), msg)
+  elseif byte == GameStore.RecivedPackets.C_RequestStoreOffers then
+    parseRequestStoreOffers(player:getId(), msg)
+  elseif byte == GameStore.RecivedPackets.C_BuyStoreOffer then
+    parseBuyStoreOffer(player:getId(), msg)
+  elseif byte == GameStore.RecivedPackets.C_OpenTransactionHistory then
+    parseOpenTransactionHistory(player:getId(), msg)
+  elseif byte == GameStore.RecivedPackets.C_RequestTransactionHistory then
+    parseRequestTransactionHistory(player:getId(), msg)
+  end
+  return true
 end
 
 function parseTransferCoins(playerId, msg)
-	local player = Player(playerId)
-	if not player then
-		return false
-	end
+  local player = Player(playerId)
+  if not player then
+    return false
+  end
 
-	local reciver = msg:getString()
-	local amount = msg:getU32()
+  local reciver = msg:getString()
+  local amount = msg:getU32()
 
-	if (player:getCoinsBalance() < amount) then
-		return addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_TRANSFER, "You don't have this amount of coins.")
-	end
+  if (player:getCoinsBalance() < amount) then
+    return addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_TRANSFER, "You don't have this amount of coins.")
+  end
 
-	if reciver:lower() == player:getName():lower() then
-		return addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_TRANSFER, "You can't transfer coins to yourself.")
-	end
+  if reciver:lower() == player:getName():lower() then
+    return addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_TRANSFER, "You can't transfer coins to yourself.")
+  end
 
-	local resultId = db.storeQuery("SELECT `account_id` FROM `players` WHERE `name` = " .. db.escapeString(reciver:lower()) .. "")
-	if not resultId then
-		return addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_TRANSFER, "We couldn't find that player.")
-	end
+  local resultId = db.storeQuery("SELECT `account_id` FROM `players` WHERE `name` = " .. db.escapeString(reciver:lower()) .. "")
+  if not resultId then
+    return addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_TRANSFER, "We couldn't find that player.")
+  end
 
-	local accountId = result.getDataInt(resultId, "account_id")
-	if accountId == player:getAccountId() then
-		return addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_TRANSFER, "You cannot transfer coin to a character in the same account.")
-	end
+  local accountId = result.getDataInt(resultId, "account_id")
+  if accountId == player:getAccountId() then
+    return addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_TRANSFER, "You cannot transfer coin to a character in the same account.")
+  end
 
-	db.query("UPDATE `accounts` SET `coins` = `coins` + " .. amount .. " WHERE `id` = " .. accountId)
-	player:removeCoinsBalance(amount)
-	addPlayerEvent(sendStorePurchaseSuccessful, 550, playerId, "You have transfered " .. amount .. " coins to " .. reciver .. " successfully")
+  db.query("UPDATE `accounts` SET `coins` = `coins` + " .. amount .. " WHERE `id` = " .. accountId)
+  player:removeCoinsBalance(amount)
+  addPlayerEvent(sendStorePurchaseSuccessful, 550, playerId, "You have transfered " .. amount .. " coins to " .. reciver .. " successfully")
 
-	-- Adding history for both reciver/sender
-	GameStore.insertHistory(accountId, GameStore.HistoryTypes.HISTORY_TYPE_NONE, player:getName() .. " transfered you this amount.", amount)
-	GameStore.insertHistory(player:getAccountId(), GameStore.HistoryTypes.HISTORY_TYPE_NONE, "You transfered this amount to " .. reciver, -1 * amount) -- negative
+  -- Adding history for both reciver/sender
+  GameStore.insertHistory(accountId, GameStore.HistoryTypes.HISTORY_TYPE_NONE, player:getName() .. " transfered you this amount.", amount)
+  GameStore.insertHistory(player:getAccountId(), GameStore.HistoryTypes.HISTORY_TYPE_NONE, "You transfered this amount to " .. reciver, -1 * amount) -- negative
 end
 
 function parseOpenStore(playerId, msg)
-	openStore(playerId)
+  openStore(playerId)
 
-	local serviceType = msg:getByte()
-	local category = GameStore.Categories and GameStore.Categories[1] or nil
+  local serviceType = msg:getByte()
+  local category = GameStore.Categories and GameStore.Categories[1] or nil
 
-	local servicesName = {
-		[GameStore.ServiceTypes.SERVICE_OUTFITS] = "outfits",
-		[GameStore.ServiceTypes.SERVICE_MOUNTS] = "mounts",
-		[GameStore.ServiceTypes.SERVICE_BLESSINGS] = "blessings"
-	}
+  local servicesName = {
+    [GameStore.ServiceTypes.SERVICE_OUTFITS] = "outfits",
+    [GameStore.ServiceTypes.SERVICE_MOUNTS] = "mounts",
+    [GameStore.ServiceTypes.SERVICE_BLESSINGS] = "blessings"
+  }
 
-	if servicesName[serviceType] then
-		category = GameStore.getCategoryByName(servicesName[serviceType])
-	end
+  if servicesName[serviceType] then
+    category = GameStore.getCategoryByName(servicesName[serviceType])
+  end
 
-	if category then
-		addPlayerEvent(sendShowStoreOffers, 350, playerId, category)
-	end
+  if category then
+    addPlayerEvent(sendShowStoreOffers, 350, playerId, category)
+  end
 end
 
 function parseRequestStoreOffers(playerId, msg)
-	local player = Player(playerId)
-	if not player then
-		return false
-	end
+  local player = Player(playerId)
+  if not player then
+    return false
+  end
 
-	local serviceType = GameStore.ServiceTypes.SERVICE_STANDERD
-	if player:getClient().version >= 1092 then
-		serviceType = msg:getByte()
-	end
+  local serviceType = GameStore.ServiceTypes.SERVICE_STANDERD
+  if player:getClient().version >= 1092 then
+    serviceType = msg:getByte()
+  end
 
-	local categoryName = msg:getString()
+  local categoryName = msg:getString()
 
-	local category = GameStore.getCategoryByName(categoryName)
-	if category then
-		addPlayerEvent(sendShowStoreOffers, 350, playerId, category)
-	end
+  local category = GameStore.getCategoryByName(categoryName)
+  if category then
+    addPlayerEvent(sendShowStoreOffers, 350, playerId, category)
+  end
 end
 
 function parseBuyStoreOffer(playerId, msg)
-	local player = Player(playerId)
-	if not player then
-		return false
-	end
+  local player = Player(playerId)
+  local id = msg:getU32()
+  local offer = GameStore.getOfferById(id)
+  local productType = msg:getByte()
 
-	local offerId = msg:getU32()
-	local productType = msg:getByte()
-	local offer = GameStore.getOfferById(offerId)
+  -- All guarding conditions under which the offer should not be processed must be included here
+  if (table.contains(GameStore.OfferTypes, offer.type) == false)                      -- we've got an invalid offer type
+      or (not player)                                                                 -- player not found
+      or (player:getVocation():getId() == 0) and (not GameStore.haveOfferRook(id))    -- we don't have such offer
+      or (not offer)                                                                  -- we could not find the offer
+      or (offer.type == GameStore.OfferTypes.OFFER_TYPE_NONE)                         -- offer is disabled
+      or (offer.type ~= GameStore.OfferTypes.OFFER_TYPE_NAMECHANGE and
+          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_EXPBOOST and
+          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_PREYBONUS and
+          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_PREYSLOT and
+          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_TEMPLE and
+          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_SEXCHANGE and
+          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_POUNCH and
+          not offer.id) then
+    return queueSendStoreAlertToUser("This offer is unavailable [1]", 350, playerId, GameStore.StoreErrors.STORE_ERROR_INFORMATION)
+  end
 
-	if (player:getVocation():getId() == 0) then
-		if (not GameStore.haveOfferRook(offerId)) then
-			return addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_TRANSFER, "The offer is either fake or corrupt.")
-		end
-	end
+  -- At this point the purchase is assumed to be formatted correctly
+  local offerPrice = offer.type == GameStore.OfferTypes.OFFER_TYPE_EXPBOOST and GameStore.ExpBoostValues[player:getStorageValue(51052)] or offer.price
 
-	if offer then
-		-- If we don't add type, or offer type is fake
-		if not offer.type or offer.type == GameStore.OfferTypes.OFFER_TYPE_NONE then
-			return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "The offer is either fake or corrupt.")
-		end
+  if not player:canRemoveCoins(offerPrice) then
+    return queueSendStoreAlertToUser("You don't have enough coins. Your purchase has been cancelled.", 250, playerId)
+  end
 
-		-- If no thing id,
-		if offer.type ~= GameStore.OfferTypes.OFFER_TYPE_NAMECHANGE and 
-			offer.type ~= GameStore.OfferTypes.OFFER_TYPE_EXPBOOST and 
-			offer.type ~= GameStore.OfferTypes.OFFER_TYPE_PREYBONUS and 
-			offer.type ~= GameStore.OfferTypes.OFFER_TYPE_PREYSLOT and
-			offer.type ~= GameStore.OfferTypes.OFFER_TYPE_TEMPLE and
-			offer.type ~= GameStore.OfferTypes.OFFER_TYPE_SEXCHANGE and
-			offer.type ~= GameStore.OfferTypes.OFFER_TYPE_POUNCH and
-			not offer.thingId then
-			return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "The offer is either fake or corrupt.")
-		end
+  -- Use pcall to catch unhandled errors and send an alert to the user because the client expects it at all times; (OTClient will unlock UI)
+  -- Handled errors are thrown to indicate that the purchase has failed;
+  -- Handled errors have a code index and unhandled errors do not
+  local pcallOk, pcallError = pcall(function()
+    if offer.type == GameStore.OfferTypes.OFFER_TYPE_ITEM               then GameStore.processItemPurchase(player, offer.id, offer.count)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_POUNCH         then GameStore.processItemPurchase(player, offer.id, offer.count)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_BLESSINGS      then GameStore.processSignleBlessingPurchase(player, offer.id)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_ALLBLESSINGS   then GameStore.processAllBlessingsPurchase(player)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_PREMIUM        then GameStore.processPremiumPurchase(player, offer.id)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_STACKABLE      then GameStore.processStackablePurchase(player, offer.id, offer.count, offer.name)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_HOUSE          then GameStore.processHouseRelatedPurchase(player, offer.id, offer.count)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_OUTFIT         then GameStore.processOutfitPurchase(player, offer.sexId, offer.addon)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON   then GameStore.processOutfitPurchase(player, offer.sexId, offer.addon)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_MOUNT          then GameStore.processMountPurchase(player, offer.id)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_NAMECHANGE     then local newName = msg:getString(); GameStore.processNameChangePurchase(player, offer.id, productType, newName)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_SEXCHANGE      then GameStore.processSexChangePurchase(player)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_EXPBOOST       then GameStore.processExpBoostPuchase(player)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_PREYSLOT       then GameStore.processPreySlotPurchase(player)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_PREYBONUS      then GameStore.processPreyBonusReroll(nil, offer.count)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_TEMPLE         then GameStore.processTempleTeleportPurchase(player)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_PROMOTION      then GameStore.processPromotionPurchase(player, offer.id)
+    else
+      -- This should never happen by our convention, but just in case the guarding condition is messed up...
+      error({code = 0, message = "This offer is unavailable [2]"})
+    end
+  end)
 
-		local newPrice = nil
-		if offer.type == GameStore.OfferTypes.OFFER_TYPE_EXPBOOST then
-			newPrice = GameStore.ExpBoostValues[player:getStorageValue(51052)]
-		end
+  if not pcallOk then
+    local alertMessage = pcallError.code and pcallError.message or "Something went wrong. Your purchase has been cancelled."
 
-		-- We remove coins before doing everything, if it fails, we add coins back!
-		if not player:canRemoveCoins(newPrice or offer.price) then
-			return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "We couldn't remove coins from your account, try again later.")
-		end
+    if not pcallError.code then -- unhandled error
+      -- log some debugging info
+      print(string.format("Gamestore: Purchase failed due to an unhandled script error. \n\tStacktrace: %s\n", pcallError))
+    end
 
-		-- count is used in type(item), so we need to show (i.e 10x crystal coins)
-		local offerCountStr = offer.count and (offer.count .. "x ") or ""
-		-- The message which we will send to player!
-		local message = "You have purchased " .. offerCountStr .. offer.name .. " for " .. (newPrice or offer.price) .. " coins."
+    return queueSendStoreAlertToUser(alertMessage, 500, playerId)
+  end
 
-		-- If offer is item.
-		if offer.type == GameStore.OfferTypes.OFFER_TYPE_ITEM or offer.type == GameStore.OfferTypes.OFFER_TYPE_POUNCH then
-			if player:getFreeCapacity() < ItemType(offer.thingId):getWeight(offer.count) then
-				return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "Please make sure you have free capacity to hold this item.")
-			end
 
-			local inbox = player:getSlotItem(CONST_SLOT_STORE_INBOX)
-			if inbox and inbox:getEmptySlots() > offer.count then
-				for t = 1,offer.count do
-					inbox:addItem(offer.thingId, offer.count or 1)
-				end
-			else
-				return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "Please make sure you have free slots in your store inbox.")
-			end
-		elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_BLESSINGS then
-			 if offer.thingId == 9 then
-		for i = 1, 8 do
-			if not player:hasBlessing(i) then
-				player:addBlessing(i, 1)
-			end
-		end
-		else
-		player:addBlessing(offer.thingId, 1)
-		end
-		elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_ALLBLESSINGS then
-			player:addBlessing(1, 1)
-			player:addBlessing(2, 1)
-			player:addBlessing(3, 1)
-			player:addBlessing(4, 1)
-			player:addBlessing(5, 1)
-			player:addBlessing(6, 1)
-			player:addBlessing(7, 1)
-			player:addBlessing(8, 1)
-		elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_PREMIUM then
-			player:addPremiumDays(offer.thingId)
-		-- If offer is Stackable.
-		elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_STACKABLE then
-			local function isKegItem(itemId)
-				return itemId>=ITEM_KEG_START and itemId <= ITEM_KEG_END
-			end
-			if(isKegItem(offer.thingId)) and player:getFreeCapacity() < ItemType(offer.thingId):getWeight(1) then
-				return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "Please make sure you have free capacity to hold this item.")
-			elseif not isKegItem(offer.thingId) and player:getFreeCapacity() < ItemType(offer.thingId):getWeight(offer.count) then
-				return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "Please make sure you have free capacity to hold this item.")
-			end
-			local inbox = player:getSlotItem(CONST_SLOT_STORE_INBOX)
-			if inbox and inbox:getEmptySlots() > 0 then
-				if(isKegItem(offer.thingId)) then
-					if(offer.count >= 500) then
-						local parcel = Item(inbox:addItem(2596, 1):getUniqueId())
-						local function changeParcel(parcel)
-							local packagename = ''.. offer.count..'x '.. offer.name ..' package.'
-							if parcel then
-								parcel:setAttribute(ITEM_ATTRIBUTE_NAME, packagename)
-								local pendingCount=  offer.count
-								while(pendingCount>0) do
-									local pack
-									if(pendingCount>500) then
-										pack = 500
-									else
-										pack = pendingCount
-									end
-									local kegItem = parcel:addItem(offer.thingId, 1)
-									kegItem:setAttribute(ITEM_ATTRIBUTE_CHARGES, pack)
-									pendingCount=pendingCount-pack
-								end
-							end
-						end
-						addEvent(function() changeParcel(parcel) end, 250)
-					else
-						local kegItem = inbox:addItem(offer.thingId,1)
-						kegItem:setAttribute(ITEM_ATTRIBUTE_CHARGES, offer.count)
-					end
-				elseif (offer.count > 100) then
-					local parcel = Item(inbox:addItem(2596, 1):getUniqueId())
-					local function changeParcel(parcel)
-						local packagename = ''.. offer.count..'x '.. offer.name ..' package.'
-						if parcel then
-							parcel:setAttribute(ITEM_ATTRIBUTE_NAME, packagename)
-							local pendingCount=  offer.count
-							while(pendingCount>0) do
-								local pack
-								if(pendingCount>100) then
-									pack = 100
-								else
-									pack = pendingCount
-								end
-								parcel:addItem(offer.thingId, pack)
-								pendingCount=pendingCount-pack
-							end
-						end
-					end
-					addEvent(function() changeParcel(parcel) end, 250)
-				else
-					inbox:addItem(offer.thingId, offer.count)
-				end
-			else
-				return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "Please make sure you have free slots in your store inbox.")
-			end
-		elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_HOUSE then
-			local function isCaskItem(itemId)
-				return (itemId >= ITEM_HEALTH_CASK_START and itemId <= ITEM_HEALTH_CASK_END) or 
-					(itemId >= ITEM_MANA_CASK_START and itemId <= ITEM_MANA_CASK_END) or 
-					(itemId >= ITEM_SPIRIT_CASK_START and itemId <= ITEM_SPIRIT_CASK_END)
-			end
+  player:removeCoinsBalance(offerPrice)
+  GameStore.insertHistory(player:getAccountId(), GameStore.HistoryTypes.HISTORY_TYPE_NONE, offer.name, (offerPrice) * -1)
 
-			local inbox = player:getSlotItem(CONST_SLOT_STORE_INBOX)
-			if inbox and inbox:getEmptySlots() > 0 then
-				local decoKit = inbox:addItem(26054, 1)
-				local function changeKit(kit)
-					local decoItemName = ItemType(offer.thingId):getName()
-					if kit then
-						kit:setAttribute(ITEM_ATTRIBUTE_DESCRIPTION, "You bought this item in the Store.\nUnwrap it in your own house to create a <" ..decoItemName..">.")
-						kit:setActionId(offer.thingId)
-
-						if isCaskItem(offer.thingId) then
-							kit:setAttribute(ITEM_ATTRIBUTE_DATE, offer.count)
- 						end
-					end
-				end
-				addEvent(function() changeKit(decoKit) end, 250)
-			else
-				return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "Please make sure you have free slots in your store inbox.")
-			end
-		-- If offer is outfit/addon
-		elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_OUTFIT or offer.type == GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON then
-			local outfitLookType
-			if player:getSex() == PLAYERSEX_MALE then
-				outfitLookType = offer.thingId.male
-			else
-				outfitLookType = offer.thingId.female
-			end
-			if not outfitLookType then
-				return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "This outfit seems not to suit your sex, we are sorry for that!")
-			end
-
-			player:addOutfitAddon(outfitLookType, offer.addon or 0)
-		-- If offer is mount
-		elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_MOUNT then
-			player:addMount(offer.thingId)
-		-- If offer is name change
-		elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_NAMECHANGE then
-			-- If player typed name yet!
-			if productType == GameStore.ClientOfferTypes.CLIENT_STORE_OFFER_NAMECHANGE then
-				local newName = msg:getString()
-
-				local tile = Tile(player:getPosition())
-				if (tile) then
-					if (not tile:hasFlag(TILESTATE_PROTECTIONZONE)) then
-						return addPlayerEvent(sendStoreError, 650, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "You can change name only in Protection Zone.")
-					end
-				end
-
-				local resultId = db.storeQuery("SELECT * FROM `players` WHERE `name` = " .. db.escapeString(newName) .. "")
-				if resultId ~= false then
-					return addPlayerEvent(sendStoreError, 650, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "This name is already used, please try again!")
-				end
-
-				local result = GameStore.canChangeToName(newName)
-				if not result.ability then
-					return addPlayerEvent(sendStoreError, 650, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, result.reason)
-				end
-
-				newName = newName:lower():gsub("(%l)(%w*)", function(a, b) return string.upper(a) .. b end)
-				db.query("UPDATE `players` SET `name` = " .. db.escapeString(newName) .. " WHERE `id` = " .. player:getGuid())
-				message =  "You have successfully changed you name, relogin!"
-				addEvent(function()
-					local player = Player(playerId)
-					if not player then
-						return false
-					end
-
-					player:remove()
-				end, 500)
-			-- If not, we ask him to do!
-			else
-				return addPlayerEvent(sendRequestPurchaseData, 250, playerId, offer.id, GameStore.ClientOfferTypes.CLIENT_STORE_OFFER_NAMECHANGE)
-			end
-		-- If offer is sex change
-		elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_SEXCHANGE then
-			player:toggleSex()
-		elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_EXPBOOST then
-			local currentExpBoostTime = player:getExpBoostStamina()
-
-			player:setStoreXpBoost(50)
-			player:setExpBoostStamina(currentExpBoostTime + 3600)
-
-			if (player:getStorageValue(51052) == -1 or player:getStorageValue(51052) == 6) then
-				player:setStorageValue(51052, 1)
-			end
-
-			player:setStorageValue(51052, player:getStorageValue(51052) + 1)
-			player:setStorageValue(51053, os.time()) -- last bought
-		elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_PREYSLOT then
-			local unlockedColumns = player:getPreySlots()
-			if (unlockedColumns == 2) then
-				return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "You already have 3 slots released.")
-			end
-
-			player:addPreySlot()
-		elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_PREYBONUS then
-			player:addBonusReroll(offer.count)
-		elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_TEMPLE then
-			if (player:getCondition(CONDITION_INFIGHT) or
-				player:isPzLocked()) then
-				return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "You can't use temple teleport in fight!")
-			end
-
-			player:teleportTo(player:getTown():getTemplePosition())
-			player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
-			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'You have been teleported to your hometown.')
-		elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_PROMOTION then
-			if not GameStore.addPromotionToPlayer(playerId, offer.thingId) then
-				return false
-			end
-		-- You can add whatever offer types to suit your needs!
-		else
-			-- ToDo :: implement purchase function
-			return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "This offer is fake, please contact admin.")
-		end
-		-- Removing coins
-		player:removeCoinsBalance(newPrice or offer.price)
-		-- We add this purchase to history!
-		GameStore.insertHistory(player:getAccountId(), GameStore.HistoryTypes.HISTORY_TYPE_NONE, offerCountStr .. offer.name, (newPrice or offer.price) * -1)
-		-- Send to client that purchase is successful!
-		return addPlayerEvent(sendStorePurchaseSuccessful, 650, playerId, message)
-	end
-
-	-- If we didn't found the offer or error happened
-	addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_INFORMATION, "We couldn't locate this offer, please try again later.")
+  local message = string.format("You have purchased %s for %d coins.", offer.name, offerPrice)
+  return addPlayerEvent(sendStorePurchaseSuccessful, 650, playerId, message)
 end
 
 -- Both functions use same formula!
 function parseOpenTransactionHistory(playerId, msg)
-	local page = 1
-	GameStore.DefaultValues.DEFAULT_VALUE_ENTRIES_PER_PAGE = msg:getByte()
-	sendStoreTransactionHistory(playerId, page, GameStore.DefaultValues.DEFAULT_VALUE_ENTRIES_PER_PAGE)
+  local page = 1
+  GameStore.DefaultValues.DEFAULT_VALUE_ENTRIES_PER_PAGE = msg:getByte()
+  sendStoreTransactionHistory(playerId, page, GameStore.DefaultValues.DEFAULT_VALUE_ENTRIES_PER_PAGE)
 end
 
 function parseRequestTransactionHistory(playerId, msg)
-	local page = msg:getU32()
-	sendStoreTransactionHistory(playerId, page, GameStore.DefaultValues.DEFAULT_VALUE_ENTRIES_PER_PAGE)
+  local page = msg:getU32()
+  sendStoreTransactionHistory(playerId, page, GameStore.DefaultValues.DEFAULT_VALUE_ENTRIES_PER_PAGE)
 end
 
 local function getCategoriesRook()
-	local tmpTable, count = {}, 0
-	for i, v in pairs(GameStore.Categories) do
-		if (v.rookgaard) then
-			tmpTable[#tmpTable+1] = v
-			count = count + 1
-		end
-	end
+  local tmpTable, count = {}, 0
+  for i, v in pairs(GameStore.Categories) do
+    if (v.rookgaard) then
+      tmpTable[#tmpTable + 1] = v
+      count = count + 1
+    end
+  end
 
-	return tmpTable, count
+  return tmpTable, count
 end
 
 --==Sending==--
 function openStore(playerId)
-	local player = Player(playerId)
-	if not player then
-		return false
-	end
+  local player = Player(playerId)
+  if not player then
+    return false
+  end
 
-	if not GameStore.Categories then
-		return false
-	end
-	local msg = NetworkMessage()
-	msg:addByte(GameStore.SendingPackets.S_OpenStore)
-	msg:addByte(0x00)
+  if not GameStore.Categories then
+    return false
+  end
+  local msg = NetworkMessage()
+  msg:addByte(GameStore.SendingPackets.S_OpenStore)
+  msg:addByte(0x00)
 
-	local GameStoreCategories, GameStoreCount = nil, 0
-	if (player:getVocation():getId() == 0) then
-		GameStoreCategories, GameStoreCount = getCategoriesRook()
-	else
-		GameStoreCategories, GameStoreCount = GameStore.Categories, #GameStore.Categories
-	end 
+  local GameStoreCategories, GameStoreCount = nil, 0
+  if (player:getVocation():getId() == 0) then
+    GameStoreCategories, GameStoreCount = getCategoriesRook()
+  else
+    GameStoreCategories, GameStoreCount = GameStore.Categories, #GameStore.Categories
+  end
 
-	if (GameStoreCategories) then
-		msg:addU16(GameStoreCount)
-		for k, category in ipairs(GameStoreCategories) do
-			msg:addString(category.name)
-			msg:addString(category.description)
+  if (GameStoreCategories) then
+    msg:addU16(GameStoreCount)
+    for k, category in ipairs(GameStoreCategories) do
+      msg:addString(category.name)
+      msg:addString(category.description)
 
-			if player:getClient().version >= 1093 then
-				msg:addByte(category.state or GameStore.States.STATE_NONE)
-			end
+      if player:getClient().version >= 1093 then
+        msg:addByte(category.state or GameStore.States.STATE_NONE)
+      end
 
-			msg:addByte(#category.icons)
-			for m, icon in ipairs(category.icons) do
-				msg:addString(icon)
-			end
+      msg:addByte(#category.icons)
+      for m, icon in ipairs(category.icons) do
+        msg:addString(icon)
+      end
 
-			msg:addString(category.parentCategory)
-		end
-		msg:sendToPlayer(player)
+      msg:addString(category.parentCategory)
+    end
+    msg:sendToPlayer(player)
 
-		sendCoinBalanceUpdating(playerId, true)
-	end
+    sendCoinBalanceUpdating(playerId, true)
+  end
 end
 
 function sendShowStoreOffers(playerId, category)
-	local player = Player(playerId)
-	if not player then
-		return false
-	end
+  local player = Player(playerId)
+  if not player then
+    return false
+  end
 
-	local msg = NetworkMessage()
-	local haveSaleOffer = 0
-	msg:addByte(GameStore.SendingPackets.S_StoreOffers)
+  local msg = NetworkMessage()
+  local haveSaleOffer = 0
+  msg:addByte(GameStore.SendingPackets.S_StoreOffers)
 
-	msg:addString(category.name)
+  msg:addString(category.name)
 
-	msg:addU16(category.offers and #category.offers or 0x00)
+  msg:addU16(category.offers and #category.offers or 0x00)
 
-	if category.offers then
-		for k, offer in ipairs(category.offers) do
-			msg:addU32(offer.id and offer.id or 0xFFFF) -- we later detect this number!
+  if category.offers then
+    for k, offer in ipairs(category.offers) do
+      msg:addU32(offer.id and offer.id or 0xFFFF) -- we later detect this number!
 
-			local name = ""
-			if offer.type == GameStore.OfferTypes.OFFER_TYPE_ITEM and offer.count then
-				name = offer.count .. "x "
-			end
+      local name = ""
+      if offer.type == GameStore.OfferTypes.OFFER_TYPE_ITEM and offer.count then
+        name = offer.count .. "x "
+      end
 
-			if offer.type == GameStore.OfferTypes.OFFER_TYPE_STACKABLE and offer.count then
-				name = offer.count .. "x "
-			end
+      if offer.type == GameStore.OfferTypes.OFFER_TYPE_STACKABLE and offer.count then
+        name = offer.count .. "x "
+      end
 
-			name = name .. (offer.name or "Something Special")
+      name = name .. (offer.name or "Something Special")
 
-			msg:addString(name)
-			msg:addString(offer.description or GameStore.getDefaultDescription(offer.type))
+      msg:addString(name)
+      msg:addString(offer.description or GameStore.getDefaultDescription(offer.type))
 
-			local newPrice = nil
-			if (offer.state == GameStore.States.STATE_SALE) then
-				local daySub = offer.validUntil-os.date("*t").day
-				if (daySub < 0) then
-					newPrice = offer.basePrice
-				end
-			end
+      local newPrice = nil
+      if (offer.state == GameStore.States.STATE_SALE) then
+        local daySub = offer.validUntil - os.date("*t").day
+        if (daySub < 0) then
+          newPrice = offer.basePrice
+        end
+      end
 
-			xpBoostPrice = nil
-			if offer.type == GameStore.OfferTypes.OFFER_TYPE_EXPBOOST then
-				xpBoostPrice = GameStore.ExpBoostValues[player:getStorageValue(51052)]
-			end
+      xpBoostPrice = nil
+      if offer.type == GameStore.OfferTypes.OFFER_TYPE_EXPBOOST then
+        xpBoostPrice = GameStore.ExpBoostValues[player:getStorageValue(51052)]
+      end
 
-			if xpBoostPrice then
-				msg:addU32(xpBoostPrice)
-			else
-				msg:addU32(newPrice or offer.price or 0xFFFF)
-			end
+      if xpBoostPrice then
+        msg:addU32(xpBoostPrice)
+      else
+        msg:addU32(newPrice or offer.price or 0xFFFF)
+      end
 
-			if (offer.state) then
-				if (offer.state == GameStore.States.STATE_SALE) then
-					local daySub = offer.validUntil-os.date("*t").day
-					if (daySub >= 0) then
-						msg:addByte(offer.state)
-						msg:addU32(os.time()+daySub*86400)
-						msg:addU32(offer.basePrice)
-						haveSaleOffer = 1
-					else
-						msg:addByte(GameStore.States.STATE_NONE)
-					end
-				else
-					msg:addByte(offer.state)
-				end
-			else
-				msg:addByte(GameStore.States.STATE_NONE)
-			end
+      if (offer.state) then
+        if (offer.state == GameStore.States.STATE_SALE) then
+          local daySub = offer.validUntil - os.date("*t").day
+          if (daySub >= 0) then
+            msg:addByte(offer.state)
+            msg:addU32(os.time() + daySub * 86400)
+            msg:addU32(offer.basePrice)
+            haveSaleOffer = 1
+          else
+            msg:addByte(GameStore.States.STATE_NONE)
+          end
+        else
+          msg:addByte(offer.state)
+        end
+      else
+        msg:addByte(GameStore.States.STATE_NONE)
+      end
 
-			local disabled, disabledReason = 0, ""
-			if offer.disabled == true or not offer.type then
-				disabled = 1
-			end
+      local disabled, disabledReason = 0, ""
+      if offer.disabled == true or not offer.type then
+        disabled = 1
+      end
 
-			if offer.type ~= GameStore.OfferTypes.OFFER_TYPE_NAMECHANGE and 
-				offer.type ~= GameStore.OfferTypes.OFFER_TYPE_EXPBOOST and 
-				offer.type ~= GameStore.OfferTypes.OFFER_TYPE_PREYSLOT and 
-				offer.type ~= GameStore.OfferTypes.OFFER_TYPE_PREYBONUS and
-				offer.type ~= GameStore.OfferTypes.OFFER_TYPE_TEMPLE and 
-				offer.type ~= GameStore.OfferTypes.OFFER_TYPE_SEXCHANGE and 
-				offer.type ~= GameStore.OfferTypes.OFFER_TYPE_POUNCH and 
-				not offer.thingId then
-				disabled = 1
-			end
+      if offer.type ~= GameStore.OfferTypes.OFFER_TYPE_NAMECHANGE and
+          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_EXPBOOST and
+          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_PREYSLOT and
+          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_PREYBONUS and
+          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_TEMPLE and
+          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_SEXCHANGE and
+          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_POUNCH and
+          not offer.id then
+        disabled = 1
+      end
 
-			if disabled == 1 and offer.disabledReason then -- dynamic disable
-				disabledReason = offer.disabledReason
-			end
+      if disabled == 1 and offer.disabledReason then
+        -- dynamic disable
+        disabledReason = offer.disabledReason
+      end
 
-			if disabled ~= 1 then
-				if offer.type == GameStore.OfferTypes.OFFER_TYPE_POUNCH then
-				local pounch = player:getItemById(26377, true)
-					if pounch then
-					disabled = 1
-					disabledReason = "You already have Gold Pounch."
-					end
-			end
-				if offer.type == GameStore.OfferTypes.OFFER_TYPE_BLESSINGS then
-					if player:hasBlessing(offer.thingId) and offer.thingId < 9 then
-					disabled = 1
-					disabledReason = "You already have this Bless."
-				else
-					if player:hasBlessing(1) and player:hasBlessing(2) and player:hasBlessing(3) and player:hasBlessing(4) and player:hasBlessing(5) and player:hasBlessing(6) and player:hasBlessing(7) and player:hasBlessing(8) then
-					disabled = 1
-					disabledReason = "You already have all Blessings."
-					end
-					end
-				end
-				if offer.type == GameStore.OfferTypes.OFFER_TYPE_OUTFIT or offer.type == GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON then
-					local outfitLookType
-					if player:getSex() == PLAYERSEX_MALE then
-						outfitLookType = offer.thingId.male
-					else
-						outfitLookType = offer.thingId.female
-					end
+      if disabled ~= 1 then
+        if offer.type == GameStore.OfferTypes.OFFER_TYPE_POUNCH then
+          local pounch = player:getItemById(26377, true)
+          if pounch then
+            disabled = 1
+            disabledReason = "You already have Gold Pounch."
+          end
+        elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_BLESSINGS then
+          if player:hasBlessing(offer.id) and offer.id < 9 then
+            disabled = 1
+            disabledReason = "You already have this Bless."
+          end
+        elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_ALLBLESSINGS then
+          if player:hasBlessing(1) and player:hasBlessing(2) and player:hasBlessing(3) and player:hasBlessing(4) and player:hasBlessing(5) and player:hasBlessing(6) and player:hasBlessing(7) and player:hasBlessing(8) then
+            disabled = 1
+            disabledReason = "You already have all Blessings."
+          end
+        elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_OUTFIT or offer.type == GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON then
+          local outfitLookType
+          if player:getSex() == PLAYERSEX_MALE then
+            outfitLookType = offer.sexId.male
+          else
+            outfitLookType = offer.sexId.female
+          end
 
-					if outfitLookType then
-						if offer.type == GameStore.OfferTypes.OFFER_TYPE_OUTFIT and player:hasOutfit(outfitLookType) then
-							disabled = 1
-							disabledReason = "You already have this outfit."
-						elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON then
-							if player:hasOutfit(outfitLookType) then
-								if player:hasOutfit(outfitLookType, offer.addon) then
-									disabled = 1
-									disabledReason = "You already have this addon."
-								end
-							else
-								disabled = 1
-								disabledReason = "You don't have the outfit, you can't buy the addon."
-							end
-						end
-					else
-						disabled = 1
-						disabledReason = "The offer is fake."
-					end
-				elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_MOUNT then
-					local hasMount = player:hasMount(offer.thingId)
-					if hasMount == true then
-						disabled = 1
-						disabledReason = "You already have this mount."
-					end
-				elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_PROMOTION then
-					if GameStore.canAddPromotionToPlayer(playerId, offer.thingId).ability == false then
-						disabled = 1
-						disabledReason = "You can't get this promotion"
-					end
-				elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_PREYSLOT then
-					local unlockedColumns = player:getPreySlots()
-					if (unlockedColumns == 2) then
-						disabled = 1
-						disabledReason = "You already have 3 slots released."
-					end
-					elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_EXPBOOST then
-					if (player:getStorageValue(51052) == 6 and (os.time() - player:getStorageValue(51053)) < 86400)  then
-						disabled = 1
-						disabledReason = "You can't buy XP Boost for today."
-					end
-				end
-			end
+          if outfitLookType then
+            if offer.type == GameStore.OfferTypes.OFFER_TYPE_OUTFIT and player:hasOutfit(outfitLookType) then
+              disabled = 1
+              disabledReason = "You already have this outfit."
+            elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_OUTFIT_ADDON then
+              if player:hasOutfit(outfitLookType) then
+                if player:hasOutfit(outfitLookType, offer.addon) then
+                  disabled = 1
+                  disabledReason = "You already have this addon."
+                end
+              else
+                disabled = 1
+                disabledReason = "You don't have the outfit, you can't buy the addon."
+              end
+            end
+          else
+            disabled = 1
+            disabledReason = "The offer is fake."
+          end
+        elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_MOUNT then
+          local hasMount = player:hasMount(offer.id)
+          if hasMount == true then
+            disabled = 1
+            disabledReason = "You already have this mount."
+          end
+        elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_PROMOTION then
+          if GameStore.canAddPromotionToPlayer(playerId, offer.id).ability == false then
+            disabled = 1
+            disabledReason = "You can't get this promotion"
+          end
+        elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_PREYSLOT then
+          local unlockedColumns = player:getPreySlots()
+          if (unlockedColumns == 2) then
+            disabled = 1
+            disabledReason = "You already have 3 slots released."
+          end
+        elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_EXPBOOST then
+          if (player:getStorageValue(51052) == 6 and (os.time() - player:getStorageValue(51053)) < 86400) then
+            disabled = 1
+            disabledReason = "You can't buy XP Boost for today."
+          end
+        end
+      end
 
-			msg:addByte(disabled)
+      if table.contains({ CLIENTOS_OTCLIENT_LINUX, CLIENTOS_OTCLIENT_WINDOWS, CLIENTOS_OTCLIENT_MAC }, player:getClient().os) then
+        if disabled == 1 then
+          msg:addByte(0) -- offer type 0 means disabled
+        else
+          msg:addByte(offer.type)
+        end
+      else
+        -- supporting the old way
+        msg:addByte(disabled)
+      end
 
-			if disabled == 1 and player:getClient().version >= 1093 then
-				msg:addString(disabledReason)
-			end
+      if disabled == 1 and player:getClient().version >= 1093 then
+        msg:addString(disabledReason)
+      end
 
-			msg:addByte(#offer.icons)
-			for k, icon in ipairs(offer.icons) do
-				msg:addString(icon)
-			end
+      msg:addByte(#offer.icons)
+      for k, icon in ipairs(offer.icons) do
+        msg:addString(icon)
+      end
 
-			msg:addU16(0) -- We still don't support SubOffers!
-		end
-	end
+      msg:addU16(0) -- We still don't support SubOffers!
+    end
+  end
 
-	player:sendButtonIndication(haveSaleOffer, 1)
-	msg:sendToPlayer(player)
+  player:sendButtonIndication(haveSaleOffer, 1)
+  msg:sendToPlayer(player)
 end
 
 function sendStoreTransactionHistory(playerId, page, entriesPerPage)
-	local player = Player(playerId)
-	if not player then
-		return false
-	end
+  local player = Player(playerId)
+  if not player then
+    return false
+  end
 
-	local entries = GameStore.retrieveHistoryEntries(player:getAccountId()) -- this makes everything easy!
-	if #entries == 0 then
-		return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_HISTORY, "You don't have any entries yet.")
-	end
+  local entries = GameStore.retrieveHistoryEntries(player:getAccountId()) -- this makes everything easy!
+  if #entries == 0 then
+    return addPlayerEvent(sendStoreError, 250, playerId, GameStore.StoreErrors.STORE_ERROR_HISTORY, "You don't have any entries yet.")
+  end
 
-	local toSkip = (page - 1) * entriesPerPage
-	for i = 1, toSkip do
-		table.remove(entries, 1) -- we remove first!
-	end
+  local toSkip = (page - 1) * entriesPerPage
+  for i = 1, toSkip do
+    table.remove(entries, 1) -- we remove first!
+  end
 
-	local msg = NetworkMessage()
-	msg:addByte(GameStore.SendingPackets.S_OpenTransactionHistory)
-	msg:addU32(page)
-	msg:addU32(#entries > entriesPerPage and 0x01 or 0x00)
+  local msg = NetworkMessage()
+  msg:addByte(GameStore.SendingPackets.S_OpenTransactionHistory)
+  msg:addU32(page)
+  msg:addU32(#entries > entriesPerPage and 0x01 or 0x00)
 
-	msg:addByte(#entries >= entriesPerPage and entriesPerPage or #entries)
-	for k, entry in ipairs(entries) do
-		if k >= entriesPerPage then break end
-		msg:addU32(entry.time)
-		msg:addByte(entry.mode)
-		msg:addU32(entry.amount)
-		msg:addString(entry.description)
-	end
-	msg:sendToPlayer(player)
+  msg:addByte(#entries >= entriesPerPage and entriesPerPage or #entries)
+  for k, entry in ipairs(entries) do
+    if k >= entriesPerPage then break end
+    msg:addU32(entry.time)
+    msg:addByte(entry.mode)
+    msg:addU32(entry.amount)
+    msg:addString(entry.description)
+  end
+  msg:sendToPlayer(player)
 end
 
 function sendStorePurchaseSuccessful(playerId, message)
-	local player = Player(playerId)
-	if not player then
-		return false
-	end
+  local player = Player(playerId)
+  if not player then
+    return false
+  end
 
-	local msg = NetworkMessage()
-	msg:addByte(GameStore.SendingPackets.S_CompletePurchase)
+  local msg = NetworkMessage()
+  msg:addByte(GameStore.SendingPackets.S_CompletePurchase)
 
-	msg:addByte(0x00)
+  msg:addByte(0x00)
 
-	msg:addString(message)
-	msg:addU32(player:getCoinsBalance())
-	msg:addU32(player:getCoinsBalance())
+  msg:addString(message)
+  msg:addU32(player:getCoinsBalance())
+  msg:addU32(player:getCoinsBalance())
 
-	msg:sendToPlayer(player)
+  msg:sendToPlayer(player)
 end
 
 function sendStoreError(playerId, errorType, message)
-	local player = Player(playerId)
-	if not player then
-		return false
-	end
+  local player = Player(playerId)
+  if not player then
+    return false
+  end
 
-	local msg = NetworkMessage()
-	msg:addByte(GameStore.SendingPackets.S_StoreError)
+  local msg = NetworkMessage()
+  msg:addByte(GameStore.SendingPackets.S_StoreError)
 
-	msg:addByte(errorType)
-	msg:addString(message)
+  msg:addByte(errorType)
+  msg:addString(message)
 
-	msg:sendToPlayer(player)
+  msg:sendToPlayer(player)
 end
 
 function sendCoinBalanceUpdating(playerId, updating)
-	local player = Player(playerId)
-	if not player then
-		return false
-	end
+  local player = Player(playerId)
+  if not player then
+    return false
+  end
 
-	local msg = NetworkMessage()
-	msg:addByte(GameStore.SendingPackets.S_CoinBalanceUpdating)
-	msg:addByte(0x00)
-	msg:sendToPlayer(player)
+  local msg = NetworkMessage()
+  msg:addByte(GameStore.SendingPackets.S_CoinBalanceUpdating)
+  msg:addByte(0x00)
+  msg:sendToPlayer(player)
 
-	if updating == true then
-		sendUpdateCoinBalance(playerId)
-	end
+  if updating == true then
+    sendUpdateCoinBalance(playerId)
+  end
 end
 
 function sendUpdateCoinBalance(playerId)
-	local player = Player(playerId)
-	if not player then
-		return false
-	end
+  local player = Player(playerId)
+  if not player then
+    return false
+  end
 
-	local msg = NetworkMessage()
-	msg:addByte(GameStore.SendingPackets.S_CoinBalanceUpdating)
-	msg:addByte(0x01)
+  local msg = NetworkMessage()
+  msg:addByte(GameStore.SendingPackets.S_CoinBalanceUpdating)
+  msg:addByte(0x01)
 
-	msg:addByte(GameStore.SendingPackets.S_CoinBalance)
-	msg:addByte(0x01)
+  msg:addByte(GameStore.SendingPackets.S_CoinBalance)
+  msg:addByte(0x01)
 
-	msg:addU32(player:getCoinsBalance())
-	msg:addU32(player:getCoinsBalance())
+  msg:addU32(player:getCoinsBalance())
+  msg:addU32(player:getCoinsBalance())
 
-	msg:sendToPlayer(player)
+  msg:sendToPlayer(player)
 end
 
 function sendRequestPurchaseData(playerId, offerId, type)
-	local player = Player(playerId)
-	if not player then
-		return false
-	end
+  local player = Player(playerId)
+  if not player then
+    return false
+  end
 
-	local msg = NetworkMessage()
-	msg:addByte(GameStore.SendingPackets.S_RequestPurchaseData)
-	msg:addU32(offerId)
-	msg:addByte(type)
-	msg:sendToPlayer(player)
+  local msg = NetworkMessage()
+  msg:addByte(GameStore.SendingPackets.S_RequestPurchaseData)
+  msg:addU32(offerId)
+  msg:addByte(type)
+  msg:sendToPlayer(player)
 end
 
 --==GameStoreFunctions==--
 GameStore.getCategoryByName = function(name)
-	for k, category in ipairs(GameStore.Categories) do
-		if category.name:lower() == name:lower() then
-			return category
-		end
-	end
-	return nil
+  for k, category in ipairs(GameStore.Categories) do
+    if category.name:lower() == name:lower() then
+      return category
+    end
+  end
+  return nil
 end
 
 GameStore.getOfferById = function(id)
-	for Cat_k, category in ipairs(GameStore.Categories) do
-		if category.offers then
-			for Off_k, offer in ipairs(category.offers) do
-				if offer.id == id then
-					return offer
-				end
-			end
-		end
-	end
-	return nil
+  for Cat_k, category in ipairs(GameStore.Categories) do
+    if category.offers then
+      for Off_k, offer in ipairs(category.offers) do
+        if type(offer.id) == "number" then
+          if offer.id == id then
+            return offer
+          end
+        elseif type(offer.id) == "table" then
+          for m, offerId in pairs(offer.id) do
+            -- in case of outfits we have offer.id = {male = ..., female = ...}
+            if offerId == id then
+              return offer
+            end
+          end
+        end
+
+      end
+    end
+  end
+  return nil
 end
 
 GameStore.haveCategoryRook = function()
-	for Cat_k, category in ipairs(GameStore.Categories) do
-		if category.offers and category.rookgaard then
-			return true
-		end
-	end
+  for Cat_k, category in ipairs(GameStore.Categories) do
+    if category.offers and category.rookgaard then
+      return true
+    end
+  end
 
-	return false
+  return false
 end
 
 GameStore.haveOfferRook = function(id)
-	for Cat_k, category in ipairs(GameStore.Categories) do
-		if category.offers and category.rookgaard then
-			for Off_k, offer in ipairs(category.offers) do
-				if offer.id == id then
-					return true
-				end
-			end
-		end
-	end
-	return nil
+  for Cat_k, category in ipairs(GameStore.Categories) do
+    if category.offers and category.rookgaard then
+      for Off_k, offer in ipairs(category.offers) do
+        if offer.id == id then
+          return true
+        end
+      end
+    end
+  end
+  return nil
 end
 
 GameStore.insertHistory = function(accountId, mode, description, amount)
-	return db.query(string.format("INSERT INTO `store_history`(`account_id`, `mode`, `description`, `coin_amount`, `time`) VALUES (%s, %s, %s, %s, %s)", accountId, mode, db.escapeString(description), amount, os.time()))
+  return db.query(string.format("INSERT INTO `store_history`(`account_id`, `mode`, `description`, `coin_amount`, `time`) VALUES (%s, %s, %s, %s, %s)", accountId, mode, db.escapeString(description), amount, os.time()))
 end
 
 GameStore.retrieveHistoryEntries = function(accountId)
-	local entries = {}
-	local resultId = db.storeQuery("SELECT * FROM `store_history` WHERE `account_id` = " .. accountId .. " ORDER BY `time` DESC LIMIT 15;")
-	if resultId ~= false then
-		repeat
-			local entry = {
-				mode = result.getDataInt(resultId, "mode"),
-				description = result.getDataString(resultId, "description"),
-				amount = result.getDataInt(resultId, "coin_amount"),
-				time = result.getDataInt(resultId, "time"),
-			}
-			table.insert(entries, entry)
-		until not result.next(resultId)
-		result.free(resultId)
-	end
-	return entries
+  local entries = {}
+  local resultId = db.storeQuery("SELECT * FROM `store_history` WHERE `account_id` = " .. accountId .. " ORDER BY `time` DESC LIMIT 15;")
+  if resultId ~= false then
+    repeat
+      local entry = {
+        mode = result.getDataInt(resultId, "mode"),
+        description = result.getDataString(resultId, "description"),
+        amount = result.getDataInt(resultId, "coin_amount"),
+        time = result.getDataInt(resultId, "time"),
+      }
+      table.insert(entries, entry)
+    until not result.next(resultId)
+    result.free(resultId)
+  end
+  return entries
 end
 
 GameStore.getDefaultDescription = function(offerType)
-	local t, descList = GameStore.OfferTypes
-	if offerType == t.OFFER_TYPE_OUTFIT or offerType == t.OFFER_TYPE_OUTFIT_ADDON then
-		descList = GameStore.DefaultDescriptions.OUTFIT
-	elseif offerType == t.OFFER_TYPE_MOUNT then
-		descList = GameStore.DefaultDescriptions.MOUNT
-	elseif offerType == t.OFFER_TYPE_NAMECHANGE then
-		descList = GameStore.DefaultDescriptions.NAMECHANGE
-	elseif offerType == t.OFFER_TYPE_SEXCHANGE then
-		descList = GameStore.DefaultDescriptions.SEXCHANGE
-	elseif offerType == t.OFFER_TYPE_EXPBOOST then
-		descList = GameStore.DefaultDescriptions.EXPBOOST
-	elseif offerType == t.OFFER_TYPE_PREYSLOT then
-		descList = GameStore.DefaultDescriptions.PREYSLOT
-	elseif offerType == t.OFFER_TYPE_PREYBONUS then
-		descList = GameStore.DefaultDescriptions.PREYBONUS
-	elseif offerType == t.OFFER_TYPE_TEMPLE then
-		descList = GameStore.DefaultDescriptions.TEMPLE
-	else
-		return ""
-	end
+  local t, descList = GameStore.OfferTypes
+  if offerType == t.OFFER_TYPE_OUTFIT or offerType == t.OFFER_TYPE_OUTFIT_ADDON then
+    descList = GameStore.DefaultDescriptions.OUTFIT
+  elseif offerType == t.OFFER_TYPE_MOUNT then
+    descList = GameStore.DefaultDescriptions.MOUNT
+  elseif offerType == t.OFFER_TYPE_NAMECHANGE then
+    descList = GameStore.DefaultDescriptions.NAMECHANGE
+  elseif offerType == t.OFFER_TYPE_SEXCHANGE then
+    descList = GameStore.DefaultDescriptions.SEXCHANGE
+  elseif offerType == t.OFFER_TYPE_EXPBOOST then
+    descList = GameStore.DefaultDescriptions.EXPBOOST
+  elseif offerType == t.OFFER_TYPE_PREYSLOT then
+    descList = GameStore.DefaultDescriptions.PREYSLOT
+  elseif offerType == t.OFFER_TYPE_PREYBONUS then
+    descList = GameStore.DefaultDescriptions.PREYBONUS
+  elseif offerType == t.OFFER_TYPE_TEMPLE then
+    descList = GameStore.DefaultDescriptions.TEMPLE
+  else
+    return ""
+  end
 
-	return descList[math.floor(math.random(1, #descList))] or ""
+  return descList[math.floor(math.random(1, #descList))] or ""
 end
 
 GameStore.canChangeToName = function(name)
-	local result = {
-		ability = false
-	}
-	if name:len() < 3 or name:len() > 14 then
-		result.reason = "Your new name's length should be lower than 3 or higher than 14."
-		return result
-	end
+  local result = {
+    ability = false
+  }
+  if name:len() < 3 or name:len() > 14 then
+    result.reason = "The length of your new name must be between 3 and 14 characters."
+    return result
+  end
 
-	local match = name:gmatch("%s+")
-	local count = 0
-	for v in match do
-		count = count + 1
-	end
+  local match = name:gmatch("%s+")
+  local count = 0
+  for v in match do
+    count = count + 1
+  end
 
-	local matchtwo = name:match("^%s+")
-	if (matchtwo) then
-		result.reason = "Your new name can't have whitespace at begin."
-		return result
-	end
+  local matchtwo = name:match("^%s+")
+  if (matchtwo) then
+    result.reason = "Your new name can't have whitespace at begin."
+    return result
+  end
 
-	if (count > 1) then
-		result.reason = "Your new name have more than 1 whitespace."
-		return result
-	end
+  if (count > 1) then
+    result.reason = "Your new name have more than 1 whitespace."
+    return result
+  end
 
-	-- just copied from znote aac.
-	local words = {"owner", "gamemaster", "hoster", "admin", "staff", "tibia", "account", "god", "anal", "ass", "fuck", "sex", "hitler", "pussy", "dick", "rape", "adm", "cm", "gm", "tutor", "counsellor"}
-	local split = name:split(" ")
-	for k, word in ipairs(words) do
-		for k, nameWord in ipairs(split) do
-			if nameWord:lower() == word then
-				result.reason = "You can't use word \"" .. word .. "\" in your new name."
-				return result
-			end
-		end
-	end
+  -- just copied from znote aac.
+  local words = { "owner", "gamemaster", "hoster", "admin", "staff", "tibia", "account", "god", "anal", "ass", "fuck", "sex", "hitler", "pussy", "dick", "rape", "adm", "cm", "gm", "tutor", "counsellor" }
+  local split = name:split(" ")
+  for k, word in ipairs(words) do
+    for k, nameWord in ipairs(split) do
+      if nameWord:lower() == word then
+        result.reason = "You can't use word \"" .. word .. "\" in your new name."
+        return result
+      end
+    end
+  end
 
-	local tmpName = name:gsub("%s+", "")
-	for i = 1, #words do
-		if (tmpName:lower():find(words[i])) then
-			result.reason = "You can't use word \"" .. words[i] .. "\" with whitespace in your new name."
-			return result
-		end
-	end
+  local tmpName = name:gsub("%s+", "")
+  for i = 1, #words do
+    if (tmpName:lower():find(words[i])) then
+      result.reason = "You can't use word \"" .. words[i] .. "\" with whitespace in your new name."
+      return result
+    end
+  end
 
-	if MonsterType(name) then
-		result.reason = "Your new name \"" .. name .. "\" can't be a monster's name."
-		return result
-	elseif Npc(name) then
-		result.reason = "Your new name \"" .. name .. "\" can't be a npc's name."
-		return result
-	end
+  if MonsterType(name) then
+    result.reason = "Your new name \"" .. name .. "\" can't be a monster's name."
+    return result
+  elseif Npc(name) then
+    result.reason = "Your new name \"" .. name .. "\" can't be a npc's name."
+    return result
+  end
 
-	local letters = "{}|_*+-=<>0123456789@#%^&()/*'\\.,:;~!\"$"
-	for i = 1, letters:len() do
-		local c = letters:sub(i, i)
-		for i = 1, name:len() do
-			local m = name:sub(i, i)
-			if m == c then
-				result.reason = "You can't use this letter \"" .. c .. "\" in your new name."
-				return result
-			end
-		end
-	end
-	result.ability = true
-	return result
+  local letters = "{}|_*+-=<>0123456789@#%^&()/*'\\.,:;~!\"$"
+  for i = 1, letters:len() do
+    local c = letters:sub(i, i)
+    for i = 1, name:len() do
+      local m = name:sub(i, i)
+      if m == c then
+        result.reason = "You can't use this letter \"" .. c .. "\" in your new name."
+        return result
+      end
+    end
+  end
+  result.ability = true
+  return result
 end
 
 GameStore.canAddPromotionToPlayer = function(playerId, promotion, send)
-	local player = Player(playerId)
-	if not player then
-		return false
-	end
+  local player = Player(playerId)
+  if not player then
+    return false
+  end
 
-	local result = {
-		ability = true
-	}
-	local vocation = player:getVocation()
-	-- Working --
-	local vocationCopy, baseVocation = vocation, vocation
-	vocation = vocation:getDemotion()
-	while vocation do
-		baseVocation = vocation
-		vocation = vocation:getDemotion()
-	end
+  local result = {
+    ability = true
+  }
+  local vocation = player:getVocation()
+  -- Working --
+  local vocationCopy, baseVocation = vocation, vocation
+  vocation = vocation:getDemotion()
+  while vocation do
+    baseVocation = vocation
+    vocation = vocation:getDemotion()
+  end
 
-	local baseVocationsCount = GameStore.BaseVocationsCount or 4
+  local baseVocationsCount = GameStore.BaseVocationsCount or 4
 
-	local newVocId = (baseVocationsCount * promotion) + baseVocation:getId()
+  local newVocId = (baseVocationsCount * promotion) + baseVocation:getId()
 
-	if not Vocation(newVocId) then
-		if send then
-			addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "The offer is fake, please report it!")
-		end
-		result.ability = false
-		return result
-	end
-	-- If promotion is less than player's voc, or player don't have previous promotion
-	if newVocId <= vocationCopy:getId() then
-		if send then
-			addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "You already have this promotion!")
-		end
-		result.ability = false
-		return result
-	end
+  if not Vocation(newVocId) then
+    if send then
+      addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "The offer is fake, please report it!")
+    end
+    result.ability = false
+    return result
+  end
+  -- If promotion is less than player's voc, or player don't have previous promotion
+  if newVocId <= vocationCopy:getId() then
+    if send then
+      addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "You already have this promotion!")
+    end
+    result.ability = false
+    return result
+  end
 
-	if (newVocId - baseVocationsCount) ~= vocationCopy:getId() then
-		if send then
-			addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "You need higher promotion to get his one.")
-		end
-		result.ability = false
-		return result
-	end
+  if (newVocId - baseVocationsCount) ~= vocationCopy:getId() then
+    if send then
+      addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_NETWORK, "You need higher promotion to get his one.")
+    end
+    result.ability = false
+    return result
+  end
 
-	result.vocId = newVocId
-	return result
+  result.vocId = newVocId
+  return result
 end
 
 GameStore.addPromotionToPlayer = function(playerId, promotion)
-	local player = Player(playerId)
-	if not player then
-		return false
-	end
+  local player = Player(playerId)
+  if not player then
+    return false
+  end
 
-	local result = GameStore.canAddPromotionToPlayer(player, promotion, true)
-	if result.ability == false then return false end
+  local result = GameStore.canAddPromotionToPlayer(player, promotion, true)
+  if result.ability == false then return false end
 
-	local basics = {
-		health = 185,
-		mana = 40,
-		cap = 500
-	}
+  local basics = {
+    health = 185,
+    mana = 40,
+    cap = 500
+  }
 
-	player:setVocation(result.vocId)
-	local newVoc = player:getVocation()
-	player:setMaxHealth(basics.health + (newVoc:getHealthGain() * player:getLevel()))
-	player:setMaxMana(basics.mana + (newVoc:getManaGain() * player:getLevel()))
-	player:setCapacity(basics.cap + (newVoc:getCapacityGain() * player:getLevel()))
+  player:setVocation(result.vocId)
+  local newVoc = player:getVocation()
+  player:setMaxHealth(basics.health + (newVoc:getHealthGain() * player:getLevel()))
+  player:setMaxMana(basics.mana + (newVoc:getManaGain() * player:getLevel()))
+  player:setCapacity(basics.cap + (newVoc:getCapacityGain() * player:getLevel()))
 
-	player:addHealth(player:getMaxHealth())
-	player:addMana(player:getMaxMana())
+  player:addHealth(player:getMaxHealth())
+  player:addMana(player:getMaxMana())
 
-	player:sendTextMessage(MESSAGE_INFO_DESCR, "You have been promoted to " .. newVoc:getName())
-	return true
+  player:sendTextMessage(MESSAGE_INFO_DESCR, "You have been promoted to " .. newVoc:getName())
+  return true
+end
+
+--
+-- PURCHASE PROCESSOR FUNCTIONS
+-- Must throw an error when the purchase has not been made. The error must of
+-- take a table {code = ..., message = ...} if the error is handled. When no code
+-- index is present the error is assumed to be unhandled.
+
+function GameStore.processItemPurchase(player, offerId, offerCount)
+  if player:getFreeCapacity() < ItemType(offerId):getWeight(offerCount) then
+    return error({ code = 0, message = "Please make sure you have free capacity to hold this item."})
+  end
+
+  local inbox = player:getSlotItem(CONST_SLOT_STORE_INBOX)
+  if inbox and inbox:getEmptySlots() > offerCount then
+    for t = 1, offerCount do
+      inbox:addItem(offerId, offerCount or 1)
+    end
+  else
+    return error({ code = 0, message = "Please make sure you have free slots in your store inbox."})
+  end
+end
+
+function GameStore.processSignleBlessingPurchase(player, offerId)
+  if not player:hasBlessing(offerId) then
+    player:addBlessing(offerId, 1)
+  else
+    return error({ code = 0, message = "You already have this blessing."})
+  end
+end
+
+function GameStore.processAllBlessingsPurchase(player)
+  if player:hasBlessing(1) and player:hasBlessing(2) and player:hasBlessing(3) and player:hasBlessing(4) and player:hasBlessing(5) and player:hasBlessing(6) and player:hasBlessing(7) and player:hasBlessing(8) then
+    return error({ code = 0, message = "You already have all blessings."})
+  else
+    player:addBlessing(1, 1)
+    player:addBlessing(2, 1)
+    player:addBlessing(3, 1)
+    player:addBlessing(4, 1)
+    player:addBlessing(5, 1)
+    player:addBlessing(6, 1)
+    player:addBlessing(7, 1)
+    player:addBlessing(8, 1)
+  end
+end
+
+function GameStore.processPremiumPurchase(player, offerId)
+  player:addPremiumDays(offerId)
+end
+
+function GameStore.processStackablePurchase(player, offerId, offerCount, offerName)
+  local function isKegItem(itemId)
+    return itemId >= ITEM_KEG_START and itemId <= ITEM_KEG_END
+  end
+
+  if (isKegItem(offerId) and player:getFreeCapacity() < ItemType(offerId):getWeight(1)) or player:getFreeCapacity() < ItemType(offerId):getWeight(offerCount)then
+    return error({code = 0, message = "Please make sure you have free capacity to hold this item."})
+  end
+
+  local inbox = player:getSlotItem(CONST_SLOT_STORE_INBOX)
+  if inbox and inbox:getEmptySlots() > 0 then
+    if (isKegItem(offerId)) then
+      if (offerCount >= 500) then
+        local parcel = Item(inbox:addItem(2596, 1):getUniqueId())
+        local function changeParcel(parcel)
+          local packagename = '' .. offerCount .. 'x ' .. offerName .. ' package.'
+          if parcel then
+            parcel:setAttribute(ITEM_ATTRIBUTE_NAME, packagename)
+            local pendingCount = offerCount
+            while (pendingCount > 0) do
+              local pack
+              if (pendingCount > 500) then
+                pack = 500
+              else
+                pack = pendingCount
+              end
+              local kegItem = parcel:addItem(offerId, 1)
+              kegItem:setAttribute(ITEM_ATTRIBUTE_CHARGES, pack)
+              pendingCount = pendingCount - pack
+            end
+          end
+        end
+        addEvent(function() changeParcel(parcel) end, 250)
+      else
+        local kegItem = inbox:addItem(offerId, 1)
+        kegItem:setAttribute(ITEM_ATTRIBUTE_CHARGES, offerCount)
+      end
+    elseif (offerCount > 100) then
+      local parcel = Item(inbox:addItem(2596, 1):getUniqueId())
+      local function changeParcel(parcel)
+        local packagename = '' .. offerCount .. 'x ' .. offerName .. ' package.'
+        if parcel then
+          parcel:setAttribute(ITEM_ATTRIBUTE_NAME, packagename)
+          local pendingCount = offerCount
+          while (pendingCount > 0) do
+            local pack
+            if (pendingCount > 100) then
+              pack = 100
+            else
+              pack = pendingCount
+            end
+            parcel:addItem(offerId, pack)
+            pendingCount = pendingCount - pack
+          end
+        end
+      end
+      addEvent(function() changeParcel(parcel) end, 250)
+    else
+      inbox:addItem(offerId, offerCount)
+    end
+  else
+    return error({code = 0, message = "Please make sure you have free slots in your store inbox."})
+  end
+end
+
+function GameStore.processHouseRelatedPurchase(player, offerId, offerCount)
+  local function isCaskItem(itemId)
+    return (itemId >= ITEM_HEALTH_CASK_START and itemId <= ITEM_HEALTH_CASK_END) or
+        (itemId >= ITEM_MANA_CASK_START and itemId <= ITEM_MANA_CASK_END) or
+        (itemId >= ITEM_SPIRIT_CASK_START and itemId <= ITEM_SPIRIT_CASK_END)
+  end
+
+  local inbox = player:getSlotItem(CONST_SLOT_STORE_INBOX)
+  if inbox and inbox:getEmptySlots() > 0 then
+    local decoKit = inbox:addItem(26054, 1)
+    local function changeKit(kit)
+      local decoItemName = ItemType(offerId):getName()
+      if kit then
+        kit:setAttribute(ITEM_ATTRIBUTE_DESCRIPTION, "You bought this item in the Store.\nUnwrap it in your own house to create a <" .. decoItemName .. ">.")
+        kit:setActionId(offerId)
+
+        if isCaskItem(offerId) then
+          kit:setAttribute(ITEM_ATTRIBUTE_DATE, offerCount)
+        end
+      end
+    end
+    addEvent(function() changeKit(decoKit) end, 250)
+  else
+    return error({code = 0, message = "Please make sure you have free slots in your store inbox."})
+  end
+end
+
+function GameStore.processOutfitPurchase(player, offerSexIdTable, addon)
+  local looktype
+  local _addon = addon and addon or 0
+
+  if player:getSex() == PLAYERSEX_MALE then
+    looktype = offerSexIdTable.male
+  elseif player:getSex() == PLAYERSEX_FEMALE then
+    looktype = offerSexIdTable.female
+  end
+
+  if not looktype then
+    return error({code = 0, message = "This outfit seems not to suit your sex, we are sorry for that!"})
+  elseif (not player:hasOutfit(looktype, 0)) and (_addon == 1 or _addon == 2) then
+    return error({code = 0, message = "You must own the outfit before you can buy its addon."})
+  elseif player:hasOutfit(looktype, _addon) then
+    return error({code = 0, message = "You already own this outfit."})
+  else
+    if not (player:addOutfitAddon(looktype, _addon))  -- TFS call failed
+        or (not player:hasOutfit(looktype, _addon))   -- Additional check; if the looktype doesn't match player sex for example,
+                                                      --   then the TFS check will still pass... bug? (TODO)
+    then
+      error({ code = 0, message = "There has been an issue with your outfit purchase. Your purchase has been cancelled."})
+    end
+  end
+end
+
+function GameStore.processMountPurchase(player, offerId)
+  player:addMount(offerId)
+end
+
+function GameStore.processNameChangePurchase(player, offerId, productType, newName)
+  local playerId = player:getId()
+
+  if productType == GameStore.ClientOfferTypes.CLIENT_STORE_OFFER_NAMECHANGE then
+    local tile = Tile(player:getPosition())
+    if (tile) then
+      if (not tile:hasFlag(TILESTATE_PROTECTIONZONE)) then
+        return error({code = 1, message = "You can change name only in Protection Zone."})
+      end
+    end
+
+    local resultId = db.storeQuery("SELECT * FROM `players` WHERE `name` = " .. db.escapeString(newName) .. "")
+    if resultId ~= false then
+      return error({code = 1, message = "This name is already used, please try again!"})
+    end
+
+    local result = GameStore.canChangeToName(newName)
+    if not result.ability then
+      return error({code = 1, message = result.reason})
+    end
+
+    newName = newName:lower():gsub("(%l)(%w*)", function(a, b) return string.upper(a) .. b end)
+    db.query("UPDATE `players` SET `name` = " .. db.escapeString(newName) .. " WHERE `id` = " .. player:getGuid())
+    message = "You have successfully changed you name, relogin!"
+    addEvent(function()
+      local player = Player(playerId)
+      if not player then
+        return false
+      end
+
+      player:remove()
+    end, 500)
+    -- If not, we ask him to do!
+  else
+    return addPlayerEvent(sendRequestPurchaseData, 250, playerId, offerId, GameStore.ClientOfferTypes.CLIENT_STORE_OFFER_NAMECHANGE)
+  end
+end
+
+function GameStore.processSexChangePurchase(player)
+  player:toggleSex()
+end
+
+
+function GameStore.processExpBoostPuchase(player)
+  local currentExpBoostTime = player:getExpBoostStamina()
+
+  player:setStoreXpBoost(50)
+  player:setExpBoostStamina(currentExpBoostTime + 3600)
+
+  if (player:getStorageValue(51052) == -1 or player:getStorageValue(51052) == 6) then
+    player:setStorageValue(51052, 1)
+  end
+
+  player:setStorageValue(51052, player:getStorageValue(51052) + 1)
+  player:setStorageValue(51053, os.time()) -- last bought
+end
+
+function GameStore.processPreySlotPurchase(player)
+  local unlockedColumns = player:getPreySlots()
+  if (unlockedColumns == 2) then
+    return error({code = 0, message = "You already have 3 slots released."})
+  end
+
+  player:addPreySlot()
+end
+
+function GameStore.processPreyBonusReroll(player, offerCount)
+  player:addBonusReroll(offerCount)
+end
+
+function GameStore.processTempleTeleportPurchase(player)
+  if (player:getCondition(CONDITION_INFIGHT) or player:isPzLocked()) then
+    return error({code = 0, message = "You can't use temple teleport in fight!"})
+  end
+
+  player:teleportTo(player:getTown():getTemplePosition())
+  player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+  player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'You have been teleported to your hometown.')
+end
+
+function GameStore.processPromotionPurchase(player, offerId)
+  if not GameStore.addPromotionToPlayer(player.id, offerId) then
+    return error({code = 0})
+  end
 end
 
 --==Player==--
 function Player.getCoinsBalance(self)
-	resultId = db.storeQuery("SELECT `coins` FROM `accounts` WHERE `id` = " .. self:getAccountId())
-	if not resultId then return 0 end
-	return result.getDataInt(resultId, "coins")
+  resultId = db.storeQuery("SELECT `coins` FROM `accounts` WHERE `id` = " .. self:getAccountId())
+  if not resultId then return 0 end
+  return result.getDataInt(resultId, "coins")
 end
 
 function Player.setCoinsBalance(self, coins)
-	db.query("UPDATE `accounts` SET `coins` = " .. coins .. " WHERE `id` = " .. self:getAccountId())
-	return true
+  db.query("UPDATE `accounts` SET `coins` = " .. coins .. " WHERE `id` = " .. self:getAccountId())
+  return true
 end
 
 function Player.canRemoveCoins(self, coins)
-	if self:getCoinsBalance() < coins then
-		return false
-	end
-	return true
+  if self:getCoinsBalance() < coins then
+    return false
+  end
+  return true
 end
 
 function Player.removeCoinsBalance(self, coins)
-	if self:canRemoveCoins(coins) then
-		return self:setCoinsBalance(self:getCoinsBalance() - coins)
-	end
+  if self:canRemoveCoins(coins) then
+    return self:setCoinsBalance(self:getCoinsBalance() - coins)
+  end
 
-	return false
+  return false
 end
 
 function Player.addCoinsBalance(self, coins, update)
-	self:setCoinsBalance(self:getCoinsBalance() + coins)
-	if update then sendCoinBalanceUpdating(self, true) end
-	return true
+  self:setCoinsBalance(self:getCoinsBalance() + coins)
+  if update then sendCoinBalanceUpdating(self, true) end
+  return true
 end
 
 function Player.sendButtonIndication(self, value1, value2)
-	local msg = NetworkMessage()
-	msg:addByte(0x19)
-	msg:addByte(value1) -- Sale
-	msg:addByte(value2) -- New Item
-	msg:sendToPlayer(self)
+  local msg = NetworkMessage()
+  msg:addByte(0x19)
+  msg:addByte(value1) -- Sale
+  msg:addByte(value2) -- New Item
+  msg:sendToPlayer(self)
 end
 
 function Player.toggleSex(self)
-	local currentSex = self:getSex()
-	local playerOutfit = self:getOutfit()
+  local currentSex = self:getSex()
+  local playerOutfit = self:getOutfit()
 
-	if currentSex == PLAYERSEX_FEMALE then
-		self:setSex(PLAYERSEX_MALE)
-		playerOutfit.lookType = 128
-	else
-		self:setSex(PLAYERSEX_FEMALE)
-		playerOutfit.lookType = 136
-	end
-	self:setOutfit(playerOutfit)
+  if currentSex == PLAYERSEX_FEMALE then
+    self:setSex(PLAYERSEX_MALE)
+    playerOutfit.lookType = 128
+  else
+    self:setSex(PLAYERSEX_FEMALE)
+    playerOutfit.lookType = 136
+  end
+  self:setOutfit(playerOutfit)
 end

--- a/data/talkactions/scripts/remove_creature_by_id.lua
+++ b/data/talkactions/scripts/remove_creature_by_id.lua
@@ -1,0 +1,28 @@
+function onSay(player, words, param)
+    if not player:getGroup():getAccess() then
+        return true
+    end
+
+    if player:getAccountType() < ACCOUNT_TYPE_GOD then
+        return false
+    end
+
+    local specs = Game.getSpectators(player:getPosition(), false, false, 7, 7, 7, 7)
+    local orig = player:getPosition()
+    local isRemoved = false
+
+    for i = 1, #specs do
+        local spectator = specs[i]
+        if spectator:isCreature() and tostring(spectator:getId()) == param then
+            spectator:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+            spectator:remove()
+            isRemoved = true
+            player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, string.format("Creature with ID %s has been removed successfully.", param))
+        end
+    end
+
+    if not isRemoved then
+        orig:sendMagicEffect(CONST_ME_POFF)
+        player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Removing creature failed.")
+    end
+end

--- a/data/talkactions/scripts/remove_creature_by_name.lua
+++ b/data/talkactions/scripts/remove_creature_by_name.lua
@@ -1,0 +1,28 @@
+function onSay(player, words, param)
+    if not player:getGroup():getAccess() then
+        return true
+    end
+
+    if player:getAccountType() < ACCOUNT_TYPE_GOD then
+        return false
+    end
+
+    local specs = Game.getSpectators(player:getPosition(), false, false, 7, 7, 7, 7)
+    local orig = player:getPosition()
+    local isRemoved = false
+
+    for i = 1, #specs do
+        local spectator = specs[i]
+        if spectator:isCreature() and spectator:getName() == param then
+            spectator:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+            spectator:remove()
+            isRemoved = true
+            player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, string.format("Creature with name %s has been removed successfully.", param))
+        end
+    end
+
+    if not isRemoved then
+        orig:sendMagicEffect(CONST_ME_POFF)
+        player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Removing creature failed.")
+    end
+end

--- a/data/talkactions/talkactions.xml
+++ b/data/talkactions/talkactions.xml
@@ -26,6 +26,8 @@
 	<talkaction words="/addgm" separator=" " script="add_gm.lua" />
 	<talkaction words="/attr" separator=" " script="attributes.lua" />
 	<talkaction words="/emptyhouses" script="emptyhouses.lua" />
+	<talkaction words="/rmc" separator=" " script="remove_creature_by_id.lua"/>
+	<talkaction words="/rmcn" separator=" " script="remove_creature_by_name.lua"/>
 
 	<!-- Gamemasters -->
 	<talkaction words="/ban" separator=" " script="ban.lua" />


### PR DESCRIPTION
**Gamestore update:**
- added missing store construction kit action
- removed missing items from the shop
- fixed wrong item ids in the shop (especially related to house items)
- fixed wrong "Full Sun Priest Outfit" ids for genders (female had higher id than male)
- fixed id overwriting
- refactored gamestore script to be easier to manage
- fixed a bug where item would be charged coins even when outfit was not added to the user
- fixed a bug where getOfferById function would not handle tables on id indices for outfits
- added a way of handling script errors (handled and unhanded) during a purchase
- added support for OTClient 

**Other:**
- added two new commands for removing creatures by uid and name
- adding CLion files and tfs binary files to .gitignore
- adding looktype to description in player's onLook; handy when adding outfits to the gamestore
- fixes missing storages; these storages are used in scripts but were not present in storages

**Related:**
- A working `game_store` module for OTClient working under gamestore module of this server is available at https://github.com/metabobb/otclient
- A video demonstration is available at: https://wofofonod.tumblr.com/post/184207224312/in-game-store-module-for-otclient